### PR TITLE
Add linear predictor operator and visualization for prediction

### DIFF
--- a/configs/prediction.conf
+++ b/configs/prediction.conf
@@ -6,4 +6,8 @@
 #--visualize_rgb_camera
 --perfect_tracking
 --perfect_tracking_num_steps=10
+--prediction
+--prediction_type=linear
+--prediction_num_past_steps=10
+--prediction_num_future_steps=10
 --visualize_top_down_tracker_output

--- a/pylot.py
+++ b/pylot.py
@@ -247,15 +247,15 @@ def add_planning_component(graph,
     graph.connect([carla_op], [planning_op])
     graph.connect([planning_op], [agent_op])
 
-
 def add_debugging_component(graph, top_down_camera_setup, carla_op, camera_ops,
-                            lidar_ops, perfect_tracker_ops):
+                            lidar_ops, perfect_tracker_ops, prediction_ops):
     # Add visual operators.
     pylot.operator_creator.add_visualization_operators(
         graph,
         camera_ops,
         lidar_ops,
         perfect_tracker_ops,
+        prediction_ops,
         pylot.utils.CENTER_CAMERA_NAME,
         pylot.utils.DEPTH_CAMERA_NAME,
         pylot.utils.FRONT_SEGMENTED_CAMERA_NAME,
@@ -299,6 +299,18 @@ def add_perfect_perception_component(graph,
     return (obj_det_ops, traffic_light_det_ops, lane_det_ops, segmentation_ops)
 
 
+def add_prediction_component(graph,
+                             perfect_tracker_ops,
+                             prediction_stream_name):
+    prediction_ops = []
+    if FLAGS.prediction_type == 'linear':
+        prediction_ops.append(pylot.operator_creator.create_linear_predictor_op(
+            graph, prediction_stream_name))
+        graph.connect(perfect_tracker_ops, prediction_ops)
+
+    return prediction_ops
+
+
 def main(argv):
     # Define graph
     graph = erdos.graph.get_current_graph()
@@ -335,11 +347,15 @@ def main(argv):
         # Add segmentation operators.
         segmentation_ops = add_segmentation_component(graph, camera_ops)
 
+    prediction_ops = []
+    if FLAGS.prediction:
+        prediction_ops = add_prediction_component(graph, perfect_tracker_ops, 'prediction_output')
+
     add_ground_eval_ops(graph, obj_det_ops, camera_ops)
 
     # Add debugging operators (e.g., visualizers) to the data-flow graph.
     add_debugging_component(graph, top_down_camera_setup, carla_op, camera_ops,
-                            lidar_ops, perfect_tracker_ops)
+                            lidar_ops, perfect_tracker_ops, prediction_ops)
 
     # Add the behaviour planning agent operator.
     agent_op = add_agent_op(graph,

--- a/pylot/config.py
+++ b/pylot/config.py
@@ -209,6 +209,16 @@ flags.DEFINE_bool('perfect_tracking', False,
 flags.DEFINE_integer('perfect_tracking_num_steps', None,
                      'Limit on number of past steps returned by the perfect object tracker.')
 
+# Prediction flags.
+flags.DEFINE_bool('prediction', False,
+                  'True to enable prediction.')
+flags.DEFINE_string('prediction_type', 'linear',
+                    'Prediction type: linear')
+flags.DEFINE_integer('prediction_num_past_steps', None,
+                     'Number of past steps of each agent given to the prediction module.')
+flags.DEFINE_integer('prediction_num_future_steps', None,
+                     'Number of future steps outputted by the prediction module.')
+
 # GPU memory fractions.
 flags.DEFINE_float('obj_detection_gpu_memory_fraction', 0.3,
                    'GPU memory fraction allocated to each obj detector operator')
@@ -277,11 +287,18 @@ flags.register_multi_flags_validator(
 
 flags.register_multi_flags_validator(
     ['perfect_tracking', 'perfect_tracking_num_steps'],
-    lambda flags_dict: (not flags_dict['perfect_tracking_num_steps'] or
+    lambda flags_dict: (not flags_dict['perfect_tracking'] or
                         (flags_dict['perfect_tracking'] and
                          flags_dict['perfect_tracking_num_steps'])),
-    message='perfect_tracking must be enabled when perfect_tracking_num_steps is set')
+    message='--perfect_tracking_num_steps must be set if --perfect_tracking is set')
 
+flags.register_multi_flags_validator(
+    ['prediction', 'prediction_num_past_steps', 'prediction_num_future_steps'],
+    lambda flags_dict: (not flags_dict['prediction'] or
+                        (flags_dict['prediction'] and
+                         flags_dict['prediction_num_past_steps'] and
+                         flags_dict['prediction_num_future_steps'])),
+    message='--prediction_num_past_steps and --prediction_num_future_steps must be set if --prediction is set')
 
 def detector_accuracy_validator(flags_dict):
     if flags_dict['evaluate_obj_detection']:

--- a/pylot/debug/track_visualize_operator.py
+++ b/pylot/debug/track_visualize_operator.py
@@ -14,8 +14,8 @@ import pylot.simulation.carla_utils
 
 
 class TrackVisualizerOperator(Op):
-    """ TrackVisualizerOperator visualizes the past locations of agents
-        on the top-down segmented image.
+    """ TrackVisualizerOperator visualizes the past and predicted future
+        locations of agents on the top-down segmented image.
     """
 
     def __init__(self, name, flags, top_down_camera_setup, log_file_name=None):
@@ -31,12 +31,15 @@ class TrackVisualizerOperator(Op):
         super(TrackVisualizerOperator, self).__init__(name)
         self._logger = setup_logging(self.name, log_file_name)
         self._flags = flags
-        self._colors = {'pedestrian': [255, 0, 0],
-                        'vehicle': [0, 255, 0]}
+        self._past_colors = {'pedestrian': [255, 0, 0],
+                             'vehicle': [128, 128, 0]}
+        self._future_colors = {'pedestrian': [0, 0, 255],
+                               'vehicle': [0, 255, 0]}
 
         # Queues of incoming data.
         self._tracking_msgs = deque()
         self._top_down_segmentation_msgs = deque()
+        self._prediction_msgs = deque()
         self._lock = threading.Lock()
         self._frame_cnt = 0
 
@@ -47,6 +50,8 @@ class TrackVisualizerOperator(Op):
     def setup_streams(input_streams, top_down_stream_name):
         input_streams.filter(pylot.utils.is_tracking_stream).add_callback(
             TrackVisualizerOperator.on_tracking_update)
+        input_streams.filter(pylot.utils.is_prediction_stream).add_callback(
+            TrackVisualizerOperator.on_prediction_update)
         input_streams.filter(
             pylot.utils.is_segmented_camera_stream).filter_name(
                 top_down_stream_name).add_callback(
@@ -74,46 +79,72 @@ class TrackVisualizerOperator(Op):
         with self._lock:
             self._top_down_segmentation_msgs.append(msg)
 
+    def on_prediction_update(self, msg):
+        with self._lock:
+            self._prediction_msgs.append(msg)
+
     def on_notification(self, msg):
         # Pop the oldest message from each buffer.
+        msg_buffers = [self._tracking_msgs, self._top_down_segmentation_msgs]
+        if self._flags.prediction:
+            msg_buffers.append(self._prediction_msgs)
         with self._lock:
             if not self.synchronize_msg_buffers(
                     msg.timestamp,
-                    [self._tracking_msgs, self._top_down_segmentation_msgs]):
+                    msg_buffers):
                 return
             tracking_msg = self._tracking_msgs.popleft()
             segmentation_msg = self._top_down_segmentation_msgs.popleft()
+            if self._flags.prediction:
+                prediction_msg = self._prediction_msgs.popleft()
 
-        self._logger.info('Timestamps {} {}'.format(
-            tracking_msg.timestamp, segmentation_msg.timestamp))
+        if self._flags.prediction:
+            self._logger.info('Timestamps {} {} {}'.format(
+                tracking_msg.timestamp, segmentation_msg.timestamp, prediction_msg.timestamp))
 
-        assert (tracking_msg.timestamp == segmentation_msg.timestamp)
+            assert (tracking_msg.timestamp == segmentation_msg.timestamp == prediction_msg.timestamp)
+        else:
+            self._logger.info('Timestamps {} {}'.format(
+                tracking_msg.timestamp, segmentation_msg.timestamp))
+
+            assert (tracking_msg.timestamp == segmentation_msg.timestamp)
 
         self._frame_cnt += 1
 
         display_img = np.uint8(transform_to_cityscapes_palette(
             segmentation_msg.frame))
         for obj in tracking_msg.obj_trajectories:
-            # Intrinsic matrix of the top down segmentation camera.
-            intrinsic_matrix = pylot.simulation.utils.create_intrinsic_matrix(
-                                   self._top_down_camera_setup.width,
-                                   self._top_down_camera_setup.height,
-                                   fov=self._top_down_camera_setup.fov)
-            # Convert to screen points.
-            screen_points = [
-                loc.to_camera_view(
-                    pylot.simulation.utils.camera_to_unreal_transform(
-                        self._top_down_camera_setup.transform).matrix,
-                    intrinsic_matrix) for loc in obj.trajectory
-            ]
-
-            # Draw trajectory points on segmented image.
-            for point in screen_points:
-                if (0 <= point.x <= self._flags.carla_camera_image_width) and \
-                   (0 <= point.y <= self._flags.carla_camera_image_height):
-                    cv2.circle(display_img,
-                               (int(point.x), int(point.y)),
-                               3, self._colors[obj.obj_class], -1)
+            self._draw_trajectory_on_img(obj, display_img, False)
+        if self._flags.prediction:
+            for obj in prediction_msg.predictions:
+                display_img = self._draw_trajectory_on_img(obj, display_img, True)
         pylot.utils.add_timestamp(msg.timestamp, display_img)
         cv2.imshow('img', display_img)
         cv2.waitKey(1)
+
+    def _draw_trajectory_on_img(self, obj, img, predict):
+        # Intrinsic matrix of the top down segmentation camera.
+        intrinsic_matrix = pylot.simulation.utils.create_intrinsic_matrix(
+                               self._top_down_camera_setup.width,
+                               self._top_down_camera_setup.height,
+                               fov=self._top_down_camera_setup.fov)
+        # Convert to screen points.
+        screen_points = [
+            loc.to_camera_view(
+                pylot.simulation.utils.camera_to_unreal_transform(
+                    self._top_down_camera_setup.transform).matrix,
+                intrinsic_matrix) for loc in obj.trajectory
+        ]
+        if predict:
+            point_color = self._future_colors[obj.obj_class]
+        else:
+            point_color = self._past_colors[obj.obj_class]
+
+        # Draw trajectory points on segmented image.
+        for point in screen_points:
+            if (0 <= point.x <= self._flags.carla_camera_image_width) and \
+               (0 <= point.y <= self._flags.carla_camera_image_height):
+                cv2.circle(img,
+                           (int(point.x), int(point.y)),
+                           3, point_color, -1)
+        return img

--- a/pylot/operator_creator.py
+++ b/pylot/operator_creator.py
@@ -190,6 +190,18 @@ def create_control_op(graph):
         })
     return control_op
 
+def create_linear_predictor_op(graph, output_stream_name):
+    from pylot.prediction.linear_predictor_operator import LinearPredictorOp
+    linear_predictor_op = graph.add(
+        LinearPredictorOp,
+        name='linear_predictor',
+        init_args={
+            'output_stream_name': output_stream_name,
+            'flags': FLAGS,
+            'log_file_name': FLAGS.log_file_name,
+            'csv_file_name': FLAGS.csv_log_file_name},
+        setup_args={'output_stream_name': output_stream_name})
+    return linear_predictor_op
 
 def create_waypoint_visualizer_op(graph):
     from pylot.debug.waypoint_visualize_operator import WaypointVisualizerOperator
@@ -555,6 +567,7 @@ def add_visualization_operators(graph,
                                 camera_ops,
                                 lidar_ops,
                                 perfect_tracker_ops,
+                                prediction_ops,
                                 rgb_camera_name,
                                 depth_camera_name,
                                 front_segmented_camera_name,
@@ -602,6 +615,8 @@ def add_visualization_operators(graph,
             top_down_segmented_camera_name)
         graph.connect(camera_ops + perfect_tracker_ops,
                       [top_down_tracker_video_op])
+        if FLAGS.prediction:
+            graph.connect(prediction_ops, [top_down_tracker_video_op])
 
 
 def add_recording_operators(graph,

--- a/pylot/prediction/linear_predictor_operator.py
+++ b/pylot/prediction/linear_predictor_operator.py
@@ -1,0 +1,74 @@
+from collections import deque
+import numpy as np
+
+from erdos.message import WatermarkMessage
+from erdos.op import Op
+from erdos.utils import setup_csv_logging, setup_logging
+
+from pylot.prediction.messages import ObjPrediction, PredictionMessage
+from pylot.simulation.utils import Location
+import pylot.utils
+
+class LinearPredictorOp(Op):
+    """Operator that takes in past (x,y) locations of agents, and fits a linear model to these locations.
+    """
+
+    def __init__(self,
+                 name,
+                 output_stream_name,
+                 flags,
+                 log_file_name=None,
+                 csv_file_name=None):
+        """Initializes the LinearPredictor Operator."""
+        super(LinearPredictorOp, self).__init__(name)
+        self._logger = setup_logging(self.name, log_file_name)
+        self._csv_logger = setup_csv_logging(self.name + '-csv', csv_file_name)
+        self._flags = flags
+        self._output_stream_name = output_stream_name
+
+        self._frame_cnt = 0
+
+    @staticmethod
+    def setup_streams(input_streams, output_stream_name):
+        input_streams.filter(pylot.utils.is_ground_tracking_stream).add_callback(
+            LinearPredictorOp.generate_predicted_trajectories)
+        return [pylot.utils.create_linear_prediction_stream(output_stream_name)]
+
+    def generate_predicted_trajectories(self, msg):
+        self._logger.info('Timestamps {}'.format(msg.timestamp))
+        self._frame_cnt += 1
+        obj_predictions_list = []
+
+        for obj in msg.obj_trajectories:
+            # Time step matrices used in regression.
+            num_steps = min(self._flags.prediction_num_past_steps, len(obj.trajectory))
+            ts = np.zeros((num_steps, 2))
+            future_ts = np.zeros((self._flags.prediction_num_future_steps, 2))
+            for t in range(num_steps):
+                ts[t][0] = -t
+                ts[t][1] = 1
+            for i in range(self._flags.prediction_num_future_steps):
+                future_ts[i][0] = i + 1
+                future_ts[i][1] = 1
+        
+            xy = np.zeros((num_steps, 2))
+            for t in range(num_steps):
+                location = obj.trajectory[-(t+1)] # t-th most recent step
+                xy[t][0] = location.x
+                xy[t][1] = location.y
+            linear_model_params = np.linalg.lstsq(ts, xy)[0]
+            # Predict future steps and convert to list of locations.
+            predict_array = np.matmul(future_ts, linear_model_params)
+            predictions = []
+            for t in range(self._flags.prediction_num_future_steps):
+                predictions.append(Location(x=predict_array[t][0], y=predict_array[t][1]))
+            obj_predictions_list.append(ObjPrediction(obj.obj_class,
+                                                      obj.obj_id,
+                                                      1.0, # probability
+                                                      predictions))
+        self.get_output_stream(self._output_stream_name).send(
+            PredictionMessage(msg.timestamp, obj_predictions_list)) 
+
+    def execute(self):
+        self.spin()
+

--- a/pylot/prediction/messages.py
+++ b/pylot/prediction/messages.py
@@ -2,7 +2,8 @@ from erdos.message import Message
 
 
 class ObjPrediction(object):
-    def __init__(self, obj_id, probability, trajectory):
+    def __init__(self, obj_class, obj_id, probability, trajectory):
+        self.obj_class = obj_class
         self.id = obj_id
         self.probability = probability
         # List of (x, y, yaw, timestamp).

--- a/pylot/utils.py
+++ b/pylot/utils.py
@@ -126,6 +126,13 @@ def create_ground_tracking_stream(name):
 def is_ground_tracking_stream(stream):
     return stream.get_label('tracking') == 'true'
 
+def create_linear_prediction_stream(name):
+    return DataStream(name=name,
+                      labels={'prediction': 'true'})
+
+def is_prediction_stream(stream):
+    return stream.get_label('prediction') == 'true'
+
 # ERDOS streams
 def create_segmented_camera_stream(name):
     return DataStream(name=name,


### PR DESCRIPTION
Addresses #32.

* Adds operator that fits a linear model (at+b, ct+d) to past (x,y) locations of each agent.
* Modifies the existing trajectory visualizer to also visualize predicted trajectories. 