### PR TITLE
Adding IMU sensor

### DIFF
--- a/configs/imu.conf
+++ b/configs/imu.conf
@@ -1,0 +1,7 @@
+######### Carla config #########
+--carla_num_pedestrians=0
+--carla_num_vehicles=0
+--carla_auto_pilot
+######### Other config #########
+--imu
+--visualize_imu

--- a/pylot/config.py
+++ b/pylot/config.py
@@ -14,6 +14,7 @@ flags.DEFINE_string('csv_log_file_name', None,
 flags.DEFINE_bool('lidar', False, 'True to enable the lidar sensor')
 flags.DEFINE_bool('top_down_segmentation', False,
                   'True for enable the top down segmentation camera')
+flags.DEFINE_bool('imu', True, 'True to enable the IMU sensor')
 
 # Planning modules to enable.
 flags.DEFINE_bool('waypoint_planning_operator', False,
@@ -171,6 +172,8 @@ flags.DEFINE_bool('visualize_depth_camera', False,
                   'True to enable depth camera video operator')
 flags.DEFINE_bool('visualize_lidar', False,
                   'True to enable CARLA Lidar visualizer operator')
+flags.DEFINE_bool('visualize_imu', False,
+                  'True to enable CARLA IMU visualizer operator')
 flags.DEFINE_bool('visualize_depth_estimation', False,
                   'True to enable depth estimation visualization')
 flags.DEFINE_bool('visualize_rgb_camera', False,

--- a/pylot/debug/imu_visualizer_operator.py
+++ b/pylot/debug/imu_visualizer_operator.py
@@ -7,7 +7,8 @@ import pylot.simulation.carla_utils
 
 
 class IMUVisualizerOperator(Op):
-    """ Subscribes to IMU streams and visualizes forward linear + angular acceleration."""
+    """ Subscribes to IMU streams and visualizes forward linear + angular
+    acceleration."""
 
     def __init__(self, name, flags, log_file_name=None):
         super(IMUVisualizerOperator, self).__init__(name)
@@ -28,7 +29,8 @@ class IMUVisualizerOperator(Op):
 
     def on_imu_update(self, msg):
         """ The callback function that gets called upon receipt of the
-        IMU message to be drawn on the screen. Draws forward linear and angular acceleration.
+        IMU message to be drawn on the screen. Draws forward linear and angular
+        acceleration.
 
         Args:
             msg: A message of type `pylot.simulation.messages.IMUMessage` to

--- a/pylot/debug/imu_visualizer_operator.py
+++ b/pylot/debug/imu_visualizer_operator.py
@@ -7,8 +7,7 @@ import pylot.simulation.carla_utils
 
 
 class IMUVisualizerOperator(Op):
-    """ Subscribes to IMU streams and visualizes forward linear + angular
-    acceleration."""
+    """ Subscribes to IMU streams and visualizes forward linear acceleration."""
 
     def __init__(self, name, flags, log_file_name=None):
         super(IMUVisualizerOperator, self).__init__(name)
@@ -29,40 +28,40 @@ class IMUVisualizerOperator(Op):
 
     def on_imu_update(self, msg):
         """ The callback function that gets called upon receipt of the
-        IMU message to be drawn on the screen. Draws forward linear and angular
-        acceleration.
+        IMU message to be drawn on the screen. Draws forward linear acceleration.
 
         Args:
             msg: A message of type `pylot.simulation.messages.IMUMessage` to
                 be drawn on the screen.
         """
+
         transform = msg.transform
-        acceleration = msg.acceleration
-        gyro = msg.gyro
 
-        loc = carla.Location(transform.location.x,
-                             transform.location.y,
-                             transform.location.z)
+        # acceleration measured in ego frame, not global
+        # z acceleration not useful for visualization so set to 0
+        rotation_transform = carla.Transform(
+            location=carla.Location(0, 0, 0),
+            rotation=transform.rotation.as_carla_rotation()
+        )
+        acceleration = msg.acceleration.as_carla_vector()
+        rotated_acceleration = rotation_transform.transform(
+            carla.Location(acceleration.x, acceleration.y, 0)
+        )
+
+        # construct arrow
+        loc = transform.location.as_carla_location()
         begin_acc = loc + carla.Location(z=0.5)
-        end_acc = begin_acc + carla.Location(acceleration.x,
-                                             acceleration.y,
-                                             acceleration.z)
+        end_acc = begin_acc + carla.Location(rotated_acceleration.x,
+                                             rotated_acceleration.y,
+                                             0)  # not useful for visualization
 
-        begin_gyro = loc + carla.Location(z=0.5)
-        end_gyro = begin_gyro + carla.Location(gyro.x,
-                                               gyro.y,
-                                               gyro.z)
-
+        # draw arrow
+        self._logger.debug("Acc: {}".format(rotated_acceleration))
         self._world.debug.draw_arrow(begin_acc,
                                      end_acc,
-                                     arrow_size=0.3,
-                                     life_time=30.0,
+                                     arrow_size=0.1,
+                                     life_time=0.1,
                                      color=carla.Color(255, 0, 0))
-        self._world.debug.draw_arrow(begin_gyro,
-                                     end_gyro,
-                                     arrow_size=0.3,
-                                     life_time=30.0,
-                                     color=carla.Color(0, 255, 0))
 
     def execute(self):
         self.spin()

--- a/pylot/debug/imu_visualizer_operator.py
+++ b/pylot/debug/imu_visualizer_operator.py
@@ -1,0 +1,66 @@
+from erdos.op import Op
+from erdos.utils import setup_logging
+
+import carla
+import pylot.utils
+import pylot.simulation.carla_utils
+
+
+class IMUVisualizerOperator(Op):
+    """ Subscribes to IMU streams and visualizes forward linear + angular acceleration."""
+
+    def __init__(self, name, flags, log_file_name=None):
+        super(IMUVisualizerOperator, self).__init__(name)
+        self._logger = setup_logging(self.name, log_file_name)
+        self._flags = flags
+        _, self._world = pylot.simulation.carla_utils.get_world(
+            self._flags.carla_host,
+            self._flags.carla_port,
+            self._flags.carla_timeout)
+        if self._world is None:
+            raise ValueError("Error connecting to the simulator.")
+
+    @staticmethod
+    def setup_streams(input_streams):
+        input_streams.filter(pylot.utils.is_imu_stream).add_callback(
+            IMUVisualizerOperator.on_imu_update)
+        return []
+
+    def on_imu_update(self, msg):
+        """ The callback function that gets called upon receipt of the
+        IMU message to be drawn on the screen. Draws forward linear and angular acceleration.
+
+        Args:
+            msg: A message of type `pylot.simulation.messages.IMUMessage` to
+                be drawn on the screen.
+        """
+        transform = msg.transform
+        acceleration = msg.acceleration
+        gyro = msg.gyro
+
+        loc = carla.Location(transform.location.x,
+                             transform.location.y,
+                             transform.location.z)
+        begin_acc = loc + carla.Location(z=0.5)
+        end_acc = begin_acc + carla.Location(acceleration.x,
+                                             acceleration.y,
+                                             acceleration.z)
+
+        begin_gyro = loc + carla.Location(z=0.5)
+        end_gyro = begin_gyro + carla.Location(gyro.x,
+                                               gyro.y,
+                                               gyro.z)
+
+        self._world.debug.draw_arrow(begin_acc,
+                                     end_acc,
+                                     arrow_size=0.3,
+                                     life_time=30.0,
+                                     color=carla.Color(255, 0, 0))
+        self._world.debug.draw_arrow(begin_gyro,
+                                     end_gyro,
+                                     arrow_size=0.3,
+                                     life_time=30.0,
+                                     color=carla.Color(0, 255, 0))
+
+    def execute(self):
+        self.spin()

--- a/pylot/operator_creator.py
+++ b/pylot/operator_creator.py
@@ -11,6 +11,7 @@ from pylot.debug.segmented_video_operator import SegmentedVideoOperator
 from pylot.debug.segmented_top_down_video_operator import SegmentedTopDownVideoOperator
 from pylot.debug.track_visualize_operator import TrackVisualizerOperator
 from pylot.debug.video_operator import VideoOperator
+from pylot.debug.imu_visualizer_operator import IMUVisualizerOperator
 # Import logging operators.
 from pylot.loggers.bounding_box_logger_operator import BoundingBoxLoggerOp
 from pylot.loggers.camera_logger_operator import CameraLoggerOp
@@ -75,9 +76,10 @@ def create_camera_driver_op(graph, camera_setup):
     return camera_op
 
 
-def create_driver_ops(graph, camera_setups, lidar_setups, auto_pilot=False):
+def create_driver_ops(graph, camera_setups, lidar_setups, imu_setups, auto_pilot=False):
     camera_ops = []
     lidar_ops = []
+    imu_ops = []
     if FLAGS.carla_replay_file == '':
         carla_op = create_carla_op(graph, auto_pilot)
     else:
@@ -86,8 +88,10 @@ def create_driver_ops(graph, camera_setups, lidar_setups, auto_pilot=False):
                       for cs in camera_setups]
     lidar_ops = [create_lidar_driver_op(graph, ls)
                      for ls in lidar_setups]
-    graph.connect([carla_op], camera_ops + lidar_ops)
-    return (carla_op, camera_ops, lidar_ops)
+    imu_ops = [create_imu_driver_op(graph, ims)
+                    for ims in imu_setups]
+    graph.connect([carla_op], camera_ops + lidar_ops + imu_ops)
+    return (carla_op, camera_ops, lidar_ops, imu_ops)
 
 
 def create_camera_logger_op(graph):
@@ -140,6 +144,20 @@ def create_lidar_driver_op(graph, lidar_setup):
         },
         setup_args={'lidar_setup': lidar_setup})
     return lidar_op
+
+
+def create_imu_driver_op(graph, imu_setup):
+    from pylot.simulation.imu_driver_operator import IMUDriverOperator
+    imu_op = graph.add(
+        IMUDriverOperator,
+        name=imu_setup.name,
+        init_args={
+            'imu_setup': imu_setup,
+            'flags': FLAGS,
+            'log_file_name': FLAGS.log_file_name
+        },
+        setup_args={'imu_setup': imu_setup})
+    return imu_op
 
 
 def create_lidar_logger_op(graph):
@@ -283,6 +301,18 @@ def create_lidar_record_op(graph):
         init_args={'filename': 'pylot_lidar_data.erdos'},
         setup_args={'filter': 'lidar'})
     return record_lidar_op
+
+
+def create_imu_visualizer_op(graph):
+    imu_visualizer_op = graph.add(
+        IMUVisualizerOperator,
+        name='imu_visualizer',
+        init_args={
+            'flags': FLAGS,
+            'log_file_name': FLAGS.log_file_name
+        }
+    )
+    return imu_visualizer_op
 
 
 def create_camera_video_op(graph, name, filter_name):
@@ -599,7 +629,8 @@ def add_visualization_operators(graph,
                                 depth_camera_name,
                                 front_segmented_camera_name,
                                 top_down_segmented_camera_name,
-                                top_down_camera_setup):
+                                top_down_camera_setup,
+                                imu_ops):
     if FLAGS.visualize_rgb_camera:
         camera_video_op = create_camera_video_op(graph,
                                                  'rgb_camera',
@@ -616,6 +647,10 @@ def add_visualization_operators(graph,
     if FLAGS.visualize_lidar:
         lidar_visualizer_op = create_lidar_visualizer_op(graph)
         graph.connect(lidar_ops, [lidar_visualizer_op])
+
+    if FLAGS.visualize_imu:
+        imu_visualizer_op = create_imu_visualizer_op(graph)
+        graph.connect(imu_ops, [imu_visualizer_op])
 
     # Due to cv2 multithreading issues, the viewers for front-facing
     # and top-down segmentation have to be placed into two

--- a/pylot/operator_creator.py
+++ b/pylot/operator_creator.py
@@ -77,9 +77,6 @@ def create_camera_driver_op(graph, camera_setup):
 
 
 def create_driver_ops(graph, camera_setups, lidar_setups, imu_setups, auto_pilot=False):
-    camera_ops = []
-    lidar_ops = []
-    imu_ops = []
     if FLAGS.carla_replay_file == '':
         carla_op = create_carla_op(graph, auto_pilot)
     else:

--- a/pylot/simulation/imu_driver_operator.py
+++ b/pylot/simulation/imu_driver_operator.py
@@ -10,6 +10,7 @@ from erdos.timestamp import Timestamp
 import pylot.utils
 from pylot.simulation.carla_utils import get_world, set_synchronous_mode
 from pylot.simulation.messages import IMUMessage
+from pylot.simulation.utils import Vector3D, Transform
 
 
 class IMUDriverOperator(Op):
@@ -79,9 +80,9 @@ class IMUDriverOperator(Op):
             watermark_msg = WatermarkMessage(timestamp)
 
             msg = IMUMessage(
-                imu_msg.transform,
-                imu_msg.accelerometer,
-                imu_msg.gyroscope,
+                Transform(carla_transform=imu_msg.transform),
+                Vector3D(carla_vector=imu_msg.accelerometer),
+                Vector3D(carla_vector=imu_msg.gyroscope),
                 imu_msg.compass,
                 timestamp
             )

--- a/pylot/simulation/imu_driver_operator.py
+++ b/pylot/simulation/imu_driver_operator.py
@@ -1,0 +1,141 @@
+import threading
+import time
+
+# ERDOS specific imports.
+from erdos.op import Op
+from erdos.utils import setup_logging
+from erdos.message import WatermarkMessage
+from erdos.timestamp import Timestamp
+
+import pylot.utils
+from pylot.simulation.carla_utils import get_world, set_synchronous_mode
+from pylot.simulation.messages import IMUMessage
+
+
+class IMUDriverOperator(Op):
+    """ Publishes carla.IMUMeasurements (transform, acceleration, gyro and compass)
+    from IMU (inertial measurement unit) sensor.
+
+    This operator attaches to a vehicle at the required position with respect to
+    the vehicle, registers callback functions to retrieve the IMU measurements and
+    publishes it to downstream operators.
+
+    Attributes:
+        _imu_setup: An IMUSetup tuple.
+        _imu: Handle to the IMU inside the simulation.
+        _vehicle: Handle to the simulated hero vehicle.
+    """
+    def __init__(self,
+                 name,
+                 imu_setup,
+                 flags,
+                 log_file_name=None):
+        """ Initializes the camera inside the simulation with the given
+        parameters.
+
+        Args:
+            name: The unique name of the operator.
+            imu_setup: A IMUSetup tuple.
+            flags: A handle to the global flags instance to retrieve the
+                configuration.
+            log_file_name: The file to log the required information to.
+        """
+        super(IMUDriverOperator, self).__init__(
+            name, no_watermark_passthrough=True)
+        # The operator does not pass watermarks by defaults.
+        self._flags = flags
+        self._logger = setup_logging(self.name, log_file_name)
+        self._imu_setup = imu_setup
+        # The hero vehicle actor object we obtain from Carla.
+        self._vehicle = None
+        # The IMU sensor actor object we obtain from Carla.
+        self._imu = None
+        # Lock to ensure that the callbacks do not execute simultaneously.
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def setup_streams(input_streams, imu_setup):
+        """ Set up callback functions on the input streams and return the
+        output stream that publishes the IMU measurements.
+
+        Args:
+            input_streams: The streams that this operator is connected to.
+            imu_setup: An IMUSetup tuple.
+        """
+        input_streams.filter(pylot.utils.is_ground_vehicle_id_stream)\
+                     .add_callback(IMUDriverOperator.on_vehicle_id)
+        return [pylot.utils.create_imu_stream(imu_setup)]
+
+    def process_imu(self, imu_msg):
+        """ Invoked when an IMU message is received from the simulator.
+        Sends IMU measurements to downstream operators.
+
+        Args:
+            imu_msg: carla.IMUMeasurement
+        """
+        with self._lock:
+            game_time = int(imu_msg.timestamp * 1000)
+            timestamp = Timestamp(coordinates=[game_time])
+            watermark_msg = WatermarkMessage(timestamp)
+
+            msg = IMUMessage(
+                imu_msg.transform,
+                imu_msg.accelerometer,
+                imu_msg.gyroscope,
+                imu_msg.compass,
+                timestamp
+            )
+
+            self.get_output_stream(self._imu_setup.name).send(msg)
+            # Note: The operator is set not to automatically propagate
+            # watermark messages received on input streams. Thus, we can
+            # issue watermarks only after the Carla callback is invoked.
+            self.get_output_stream(self._imu_setup.name).send(watermark_msg)
+
+    def on_vehicle_id(self, msg):
+        """ This function receives the identifier for the vehicle, retrieves
+        the handler for the vehicle from the simulation and attaches the
+        IMU to it.
+
+        Args:
+            msg: The identifier for the vehicle to attach the camera to.
+        """
+        vehicle_id = msg.data
+        self._logger.info(
+            "The IMUDriverOperator received the vehicle id: {}".format(
+                vehicle_id))
+
+        # Connect to the world. We connect here instead of in the constructor
+        # to ensure we're connected to the latest world.
+        _, world = get_world(self._flags.carla_host,
+                             self._flags.carla_port,
+                             self._flags.carla_timeout)
+        if world is None:
+            raise ValueError("There was an issue connecting to the simulator.")
+        if self._flags.carla_synchronous_mode:
+            set_synchronous_mode(world, self._flags.carla_fps)
+
+        num_tries = 0
+        while self._vehicle is None and num_tries < 30:
+            self._vehicle = world.get_actors().find(vehicle_id)
+            self._logger.info(
+                "Could not find vehicle. Try {}".format(num_tries))
+            time.sleep(1)
+            num_tries += 1
+        if self._vehicle is None:
+            raise ValueError("There was an issue finding the vehicle.")
+
+        # Install the IMU.
+        imu_blueprint = world.get_blueprint_library().find(
+            self._imu_setup.imu_type)
+
+        transform = self._imu_setup.get_transform().as_carla_transform()
+
+        self._logger.info("Spawning an IMU: {}".format(self._imu_setup))
+
+        self._imu = world.spawn_actor(imu_blueprint,
+                                      transform,
+                                      attach_to=self._vehicle)
+
+        # Register the callback on the camera.
+        self._imu.listen(self.process_imu)

--- a/pylot/simulation/messages.py
+++ b/pylot/simulation/messages.py
@@ -87,6 +87,35 @@ class PointCloudMessage(Message):
             self.timestamp, len(self.point_cloud))
 
 
+class IMUMessage(Message):
+    """ Message class to be used to send IMU measurements.
+
+    Attributes:
+        transform: The simulation.utils.Transform of the IMU.
+        acceleration: carla.vector3D linear acceleration measurement in m/s^2
+        gyro: carla.vector3D angular velocity measurement in rad/sec
+        compass: float orientation measurement w.r.t North direction ((0, -1, 0) in Unreal) in radians
+    """
+    def __init__(self, transform, acceleration, gyro, compass, timestamp):
+        """ Initializes the IMU messsage.
+
+        Args:
+            transform: The simulation.utils.Transform of the IMU.
+            acceleration: carla.vector3D linear acceleration measurement in m/s^2
+            gyro: carla.vector3D angular velocity measurement in rad/sec
+            compass: float orientation measurement w.r.t North direction ((0, -1, 0) in Unreal) in radians
+        """
+        super(IMUMessage, self).__init__(None, timestamp, 'default')
+        self.transform = transform
+        self.acceleration = acceleration
+        self.gyro = gyro
+        self.compass = compass
+
+    def __str__(self):
+        return 'IMUMessage(timestamp: {}, transform: {}, transform: {}, transform: {}, transform: {})'.format(
+            self.timestamp, self.transform, self.acceleration, self.gyro, self.compass)
+
+
 class GroundVehiclesMessage(Message):
     """ Message class to be used to send ground info about vehicle actors.
 

--- a/pylot/simulation/messages.py
+++ b/pylot/simulation/messages.py
@@ -1,5 +1,4 @@
 from erdos.message import Message
-from pylot.simulation.utils import Vector3D, Transform
 
 
 class FrameMessage(Message):
@@ -103,15 +102,17 @@ class IMUMessage(Message):
 
         Args:
             transform: The simulation.utils.Transform of the IMU.
-            acceleration: carla.vector3D linear acceleration measurement in m/s^2
-            gyro: carla.vector3D angular velocity measurement in rad/sec
+            acceleration: simulation.utils.Vector3D linear acceleration
+                measurement in m/s^2
+            gyro: simulation.utils.Vector3D angular velocity measurement in
+                rad/sec
             compass: float orientation measurement w.r.t North direction
                 ((0, -1, 0) in Unreal) in radians
         """
         super(IMUMessage, self).__init__(None, timestamp, 'default')
-        self.transform = Transform(carla_transform=transform)
-        self.acceleration = Vector3D(carla_vector=acceleration)
-        self.gyro = Vector3D(carla_vector=gyro)
+        self.transform = transform
+        self.acceleration = acceleration
+        self.gyro = gyro
         self.compass = compass
 
     def __str__(self):

--- a/pylot/simulation/messages.py
+++ b/pylot/simulation/messages.py
@@ -1,4 +1,5 @@
 from erdos.message import Message
+from pylot.simulation.utils import Vector3D, Transform
 
 
 class FrameMessage(Message):
@@ -94,7 +95,8 @@ class IMUMessage(Message):
         transform: The simulation.utils.Transform of the IMU.
         acceleration: carla.vector3D linear acceleration measurement in m/s^2
         gyro: carla.vector3D angular velocity measurement in rad/sec
-        compass: float orientation measurement w.r.t North direction ((0, -1, 0) in Unreal) in radians
+        compass: float orientation measurement w.r.t North direction ((0, -1, 0)
+            in Unreal) in radians
     """
     def __init__(self, transform, acceleration, gyro, compass, timestamp):
         """ Initializes the IMU messsage.
@@ -103,17 +105,20 @@ class IMUMessage(Message):
             transform: The simulation.utils.Transform of the IMU.
             acceleration: carla.vector3D linear acceleration measurement in m/s^2
             gyro: carla.vector3D angular velocity measurement in rad/sec
-            compass: float orientation measurement w.r.t North direction ((0, -1, 0) in Unreal) in radians
+            compass: float orientation measurement w.r.t North direction
+                ((0, -1, 0) in Unreal) in radians
         """
         super(IMUMessage, self).__init__(None, timestamp, 'default')
-        self.transform = transform
-        self.acceleration = acceleration
-        self.gyro = gyro
+        self.transform = Transform(carla_transform=transform)
+        self.acceleration = Vector3D(carla_vector=acceleration)
+        self.gyro = Vector3D(carla_vector=gyro)
         self.compass = compass
 
     def __str__(self):
-        return 'IMUMessage(timestamp: {}, transform: {}, transform: {}, transform: {}, transform: {})'.format(
-            self.timestamp, self.transform, self.acceleration, self.gyro, self.compass)
+        return 'IMUMessage(timestamp: {}, transform: {}, transform: {}, '\
+               'transform: {}, transform: {})'.format(
+                self.timestamp, self.transform, self.acceleration, self.gyro,
+                self.compass)
 
 
 class GroundVehiclesMessage(Message):

--- a/pylot/simulation/utils.py
+++ b/pylot/simulation/utils.py
@@ -250,14 +250,20 @@ class Vector3D(object):
         z: The value of the third axis.
     """
 
-    def __init__(self, x, y, z):
+    def __init__(self, x=None, y=None, z=None, carla_vector=None):
         """ Initializes the Vector3D instance from the given x, y and z values.
+        Alternatively, pass in a carla_vector (carla.vector3D).
 
         Args:
             x: The value of the first axis.
             y: The value of the second axis.
             z: The value of the third axis.
+            carla_vector: carla.vector3D
         """
+        if carla_vector is not None:
+            x = carla_vector.x
+            y = carla_vector.y
+            z = carla_vector.z
         self.x, self.y, self.z = x, y, z
 
     def __add__(self, other):

--- a/pylot/simulation/utils.py
+++ b/pylot/simulation/utils.py
@@ -94,6 +94,23 @@ class LidarSetup(object):
                 self.lower_fov, self.points_per_second)
 
 
+class IMUSetup(object):
+    def __init__(self, name, imu_type, transform):
+        self.name = name
+        self.imu_type = imu_type
+        self.transform = transform
+
+    def get_transform(self):
+        return self.transform
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return "IMUSetup(name: {}, type: {}, transform: {})".format(
+            self.name, self.imu_type, self.transform)
+
+
 class CanBus(object):
     def __init__(self, transform, forward_speed):
         self.transform = transform

--- a/pylot/utils.py
+++ b/pylot/utils.py
@@ -65,6 +65,15 @@ def create_lidar_stream(lidar_setup):
                       labels={'sensor_type': lidar_setup.lidar_type})
 
 
+def is_imu_stream(stream):
+    return stream.get_label('sensor_type') == 'sensor.other.imu'
+
+
+def create_imu_stream(imu_setup):
+    return DataStream(name=imu_setup.name,
+                      labels={'sensor_type': imu_setup.imu_type})
+
+
 # Ground streams
 def is_ground_segmented_camera_stream(stream):
     return (stream.get_label('sensor_type') == 'camera' and


### PR DESCRIPTION
Adding the Carla IMU sensor: https://carla.readthedocs.io/en/latest/cameras_and_sensors/#sensorotherimu

The IMU sensor is setup similarly to `camera_driver_op` / `lidar_driver_op` and publishes to the `sensor.other.imu` stream. It publishes `transform (carla.Transform), acceleration (carla.Vector3D), gyro (carla.vector3D), compass (orientation relative to Unreal North (0, -1, 0))`. This stream can be filtered using the `is_imu_stream` utility in `pylot.utils`.

Note that this only works on the master branch, as the IMU sensor was added recently. To build the master branch follow: https://carla.readthedocs.io/en/latest/how_to_build_on_linux/ and set the `CARLA_HOME` path appropriately.
 
Video: https://drive.google.com/open?id=1yfW0XPH8-y8fYtkS2y_ex4DmrUc4aZAL