### PR TITLE
adding prediction visualizer

### DIFF
--- a/pylot.py
+++ b/pylot.py
@@ -293,7 +293,8 @@ def add_debugging_component(graph, top_down_camera_setup, carla_op, camera_ops,
         pylot.utils.FRONT_SEGMENTED_CAMERA_NAME,
         pylot.utils.TOP_DOWN_SEGMENTED_CAMERA_NAME,
         top_down_camera_setup,
-        imu_ops
+        imu_ops,
+        carla_op
     )
 
     # Add recording operators.
@@ -311,11 +312,6 @@ def add_debugging_component(graph, top_down_camera_setup, carla_op, camera_ops,
             graph, pylot.utils.LEFT_CAMERA_NAME, pylot.utils.RIGHT_CAMERA_NAME)
         graph.connect(camera_ops + lidar_ops + [carla_op],
                       [depth_estimation_op])
-
-    # Add operator that visualizes CanBus
-    if FLAGS.visualize_can_bus:
-        can_bus_viz_op = pylot.operator_creator.create_can_bus_visualizer(graph)
-        graph.connect([carla_op], [can_bus_viz_op])
 
 
 def add_perfect_perception_component(graph,

--- a/pylot/config.py
+++ b/pylot/config.py
@@ -200,6 +200,7 @@ flags.DEFINE_bool('visualize_top_down_tracker_output', False,
                   'True to enable visualization of top-down tracker output')
 flags.DEFINE_bool('visualize_can_bus', False, 'True to visualize can bus.')
 flags.DEFINE_bool('visualize_planning', False, 'True to visualize planning.')
+flags.DEFINE_bool('visualize_prediction', False, 'True to visualize prediction.')
 
 # Accuracy evaluation flags.
 flags.DEFINE_bool('evaluate_obj_detection', False,

--- a/pylot/debug/prediction_visualize_operator.py
+++ b/pylot/debug/prediction_visualize_operator.py
@@ -99,23 +99,9 @@ class PredictionVisualizeOperator(Op):
         transform = can_bus_msg.data.transform
 
         for prediction in prediction_msg.predictions:
-            for location in prediction.trajectory:
-                pred_trans = pylot.simulation.utils.Transform(
-                    location=pylot.simulation.utils.Location(
-                        x=location.x,
-                        y=location.y,
-                        z=location.z,
-                    ),
-                    rotation=pylot.simulation.utils.Rotation()
-                )
-                new_trans = transform * pred_trans  # convert to global from ego
-                new_location = new_trans.location
-                loc = carla.Location(new_location.x,
-                                     new_location.y,
-                                     new_location.z + 0.5)
-
+            for location in transform.transform_points(prediction.trajectory):
                 self._world.debug.draw_point(
-                    loc,
+                    location.as_carla_location(),
                     size=0.2,
                     life_time=DEFAULT_VIS_TIME,
                     color=carla.Color(0, 255, 0)

--- a/pylot/debug/prediction_visualize_operator.py
+++ b/pylot/debug/prediction_visualize_operator.py
@@ -1,0 +1,122 @@
+from collections import deque
+import threading
+
+import carla
+
+# ERDOS specific imports.
+from erdos.op import Op
+from erdos.utils import setup_logging
+
+# Pylot specific imports.
+import pylot.utils
+import pylot.simulation.carla_utils
+import pylot.simulation.utils
+
+DEFAULT_VIS_TIME = 0.1
+
+
+class PredictionVisualizeOperator(Op):
+    """ PredictionVisualizeOperator visualizes the predictions released by the
+    prediction module.
+
+    This operator listens on the `predictions` and 'can_bus' feed and draws the
+    predicted waypoints in the world.
+
+    Attributes:
+        _world: A handle to the world to draw the waypoints on.
+    """
+    def __init__(self, name, flags, log_file_name=None):
+        """ Initializes the PredictionVisualizeOperator with the given
+        parameters.
+
+        Args:
+            name: The name of the operator.
+            flags: A handle to the global flags instance to retrieve the
+                configuration.
+            log_file_name: The file to log the required information to.
+        """
+        super(PredictionVisualizeOperator, self).__init__(name)
+        self._logger = setup_logging(self.name, log_file_name)
+        self._flags = flags
+        _, self._world = pylot.simulation.carla_utils.get_world(
+            self._flags.carla_host,
+            self._flags.carla_port,
+            self._flags.carla_timeout)
+        if self._world is None:
+            raise ValueError("Error connecting to the simulator.")
+
+        self._lock = threading.Lock()
+        self._prediction_msgs = deque()
+        self._can_bus_msgs = deque()
+
+    @staticmethod
+    def setup_streams(input_streams):
+        """ This method takes in input streams called `prediction` which
+        sends a `prediction.messages.PredictionMessage` to be drawn on
+        the screen. `can_bus` stream is used because prediction messages are
+        ego-centric.
+
+        Args:
+            input_streams: A list of streams to take the input from
+
+        Returns:
+            An empty list representing that this operator does not publish
+            any output streams.
+        """
+        input_streams.filter(pylot.utils.is_prediction_stream).add_callback(
+            PredictionVisualizeOperator.on_prediction_update)
+        input_streams.filter(pylot.utils.is_can_bus_stream).add_callback(
+            PredictionVisualizeOperator.on_can_bus_update)
+        input_streams.add_completion_callback(
+            PredictionVisualizeOperator.on_notification)
+        return []
+
+    def on_prediction_update(self, msg):
+        """ The callback function that gets called upon receipt of the
+        prediction message.
+
+        Args:
+            msg: A message of type `prediction.messages.PredictionMessage` to
+                be drawn on the screen.
+        """
+        with self._lock:
+            self._prediction_msgs.append(msg)
+
+    def on_can_bus_update(self, msg):
+        """ The callback function that gets called upon receipt of the
+        can_bus message.
+
+        Args:
+            msg: A message of type `prediction.messages.PredictionMessage` to
+                be drawn on the screen.
+        """
+        with self._lock:
+            self._can_bus_msgs.append(msg)
+
+    def on_notification(self, msg):
+        prediction_msg = self._prediction_msgs.popleft()
+        can_bus_msg = self._can_bus_msgs.popleft()
+        transform = can_bus_msg.data.transform
+
+        for prediction in prediction_msg.predictions:
+            for location in prediction.trajectory:
+                pred_trans = pylot.simulation.utils.Transform(
+                    location=pylot.simulation.utils.Location(
+                        x=location.x,
+                        y=location.y,
+                        z=location.z,
+                    ),
+                    rotation=pylot.simulation.utils.Rotation()
+                )
+                new_trans = transform * pred_trans  # convert to global from ego
+                new_location = new_trans.location
+                loc = carla.Location(new_location.x,
+                                     new_location.y,
+                                     new_location.z + 0.5)
+
+                self._world.debug.draw_point(
+                    loc,
+                    size=0.2,
+                    life_time=DEFAULT_VIS_TIME,
+                    color=carla.Color(0, 255, 0)
+                )

--- a/pylot/planning/rrt_star/rrt_star_planning_operator.py
+++ b/pylot/planning/rrt_star/rrt_star_planning_operator.py
@@ -180,26 +180,15 @@ class RRTStarPlanningOperator(Op):
         for prediction in prediction_msg.predictions:
             time = 0
             # use all prediction times as potential obstacles
-            for location in prediction.trajectory:
-                prediction_transform_ego = pylot.simulation.utils.Transform(
-                    location=pylot.simulation.utils.Location(
-                        x=location.x,
-                        y=location.y,
-                        z=location.z,
-                    ),
-                    rotation=pylot.simulation.utils.Rotation()
-                )
-                # convert to global from ego
-                prediction_transform_global = vehicle_transform * prediction_transform_ego
-                prediction_location_global = prediction_transform_global.location
+            for location in vehicle_transform.transform_points(prediction.trajectory):
                 if is_within_distance_ahead(vehicle_transform.location,
-                                            prediction_location_global,
+                                            location,
                                             vehicle_transform.rotation.yaw,
                                             DEFAULT_DISTANCE_THRESHOLD):
                     # compute the obstacle origin and range of the obstacle
                     obstacle_origin = (
-                        (prediction_location_global.x - DEFAULT_OBSTACLE_LENGTH / 2,
-                         prediction_location_global.y - DEFAULT_OBSTACLE_WIDTH / 2),
+                        (location.x - DEFAULT_OBSTACLE_LENGTH / 2,
+                         location.y - DEFAULT_OBSTACLE_WIDTH / 2),
                         (DEFAULT_OBSTACLE_LENGTH, DEFAULT_OBSTACLE_WIDTH)
                     )
                     obs_id = str("{}_{}".format(prediction.id, time))

--- a/pylot/planning/rrt_star/rrt_star_planning_operator.py
+++ b/pylot/planning/rrt_star/rrt_star_planning_operator.py
@@ -181,14 +181,25 @@ class RRTStarPlanningOperator(Op):
             time = 0
             # use all prediction times as potential obstacles
             for location in prediction.trajectory:
+                prediction_transform_ego = pylot.simulation.utils.Transform(
+                    location=pylot.simulation.utils.Location(
+                        x=location.x,
+                        y=location.y,
+                        z=location.z,
+                    ),
+                    rotation=pylot.simulation.utils.Rotation()
+                )
+                # convert to global from ego
+                prediction_transform_global = vehicle_transform * prediction_transform_ego
+                prediction_location_global = prediction_transform_global.location
                 if is_within_distance_ahead(vehicle_transform.location,
-                                            location,
+                                            prediction_location_global,
                                             vehicle_transform.rotation.yaw,
                                             DEFAULT_DISTANCE_THRESHOLD):
                     # compute the obstacle origin and range of the obstacle
                     obstacle_origin = (
-                        (location.x - DEFAULT_OBSTACLE_LENGTH / 2,
-                         location.y - DEFAULT_OBSTACLE_WIDTH / 2),
+                        (prediction_location_global.x - DEFAULT_OBSTACLE_LENGTH / 2,
+                         prediction_location_global.y - DEFAULT_OBSTACLE_WIDTH / 2),
                         (DEFAULT_OBSTACLE_LENGTH, DEFAULT_OBSTACLE_WIDTH)
                     )
                     obs_id = str("{}_{}".format(prediction.id, time))


### PR DESCRIPTION
Adding a visualizer OP that draws the predicted future poses in the world.

Also moving the can_bus visualizer OP into the add_visualization_operators function.
Also makes small fix to RRT* obstacle map building (predictions were assumed to be global but are really ego centric)

Demo: https://drive.google.com/open?id=1HUOtteAvd-vX21L5hstX1uwsXGUTEsGC