### PR TITLE
Small fix to MPC config file and IMU related flags

### DIFF
--- a/configs/mpc_agent.conf
+++ b/configs/mpc_agent.conf
@@ -1,6 +1,9 @@
 ######### Carla config #########
 --carla_num_people=50
 --carla_num_vehicles=10
+######### Perception config #########
+--perfect_obstacle_detection=True
+--perfect_traffic_light_detection=True
 ######### Planning config #########
 --planning_type=waypoint
 ######### Control config #########

--- a/pylot/flags.py
+++ b/pylot/flags.py
@@ -121,7 +121,8 @@ flags.DEFINE_bool('log_detector_output', False,
                   'Enable recording of bbox annotated detector images')
 flags.DEFINE_bool('log_traffic_light_detector_output', False,
                   'Enable recording of bbox annotated tl detector images')
-
+flags.DEFINE_bool('log_imu', False,
+                  'Enable recording of IMU measurements')
 # Flag validators.
 flags.register_multi_flags_validator(
     [

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pptk
 pytest
 scikit-image<0.15
 scipy==1.2.2
+shapely==1.6.4
 tensorflow-gpu>=1.12
 torch==0.4.1
 torchvision==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "pytest",
         "scikit-image<0.15",
         "scipy==1.2.2",
+        "shapely==1.6.4",
         "tensorflow-gpu>=1.12",
         "torch==0.4.1",
         "torchvision==0.2.1",


### PR DESCRIPTION
The conf file was broken for mpc_agent, specifically it required that object detection and traffic light detection be set. log_imu was missing from the flag definitions.

Also added shapely as a requirement in the setup file as it was missing and is required in some parts of the code.