### PR TITLE
removing python3-tk from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ opencv-contrib-python>=4.1.0.25
 pid_controller
 pillow==6.2.1
 pptk
-python3-tk
 pytest
 scikit-image<0.15
 scipy==1.2.2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "pillow==6.2.1",
         "pptk",  # TODO(ionel): Fix pptk install (https://github.com/heremaps/pptk/issues/3)
         "pytest",
-        "python3-tk",
         "scikit-image<0.15",
         "scipy==1.2.2",
         "shapely==1.6.4",


### PR DESCRIPTION
Found a small issue in our current `setup.py` and `requirements.txt` files. The package `python3-tk` doesn't exist in `pip`, which leads to 
```HTTPError: 404 Client Error: Not Found for url: https://pypi.org/simple/python3-tk/``` when trying to install via `pip install python3-tk`. This PR removes the `python3-tk` package (as it should be included or available via `apt-get update`).