### PR TITLE
fixing int division bug in CSP1D

### DIFF
--- a/pylot/control/mpc/utils.py
+++ b/pylot/control/mpc/utils.py
@@ -83,7 +83,7 @@ class CubicSpline1D:
         self.c = np.linalg.solve(matrix_a, matrix_b)
         for i in range(self.nx - 1):
             self.d.append((self.c[i + 1] - self.c[i]) / (3.0 * h[i]))
-            tb = (self.a[i + 1] - self.a[i]) / h[i] - h[i] * \
+            tb = (self.a[i + 1] - self.a[i]) / (1.0 * h[i]) - h[i] * \
                  (self.c[i + 1] + 2.0 * self.c[i]) / 3.0
             self.b.append(tb)
 


### PR DESCRIPTION
Found this when I was porting code to C++, the 1st term in the equation would be rounded to 0 due to Python 2 division. Not sure if we care because Python 2 is being deprecated and we have switched to Python 3? Feel free to close this if that's the case.