### PR TITLE
Fixing flow watermarks, math domain error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.json
 *.pyc
 *.log
 *.csv
@@ -12,4 +13,4 @@ venv/
 erdos_pylot.egg-info/
 
 # Submodules handled by install.sh
-frenet-optimal-trajectory-planner/
+frenet_optimal_trajectory_planner/

--- a/configs/frenet_optimal_trajectory_planner.conf
+++ b/configs/frenet_optimal_trajectory_planner.conf
@@ -15,7 +15,7 @@
 --stop_for_vehicles=False
 --stop_for_people=False
 --stop_for_traffic_lights=False
---target_speed=20
+--target_speed=10
 --pid_steer_wp=5
 --pid_speed_wp=-1
 ######### Logging config #########
@@ -24,6 +24,3 @@
 --v=1
 ######### Visualize config #########
 --visualize_waypoints
---draw_waypoints_on_world=False
---draw_waypoints_on_camera_frames
---visualize_prediction

--- a/pylot/operator_creator.py
+++ b/pylot/operator_creator.py
@@ -443,6 +443,7 @@ def add_mpc_agent(can_bus_stream, waypoints_stream):
 
 def add_pid_agent(can_bus_stream, waypoints_stream):
     op_config = erdos.OperatorConfig(name='pid_agent_operator',
+                                     flow_watermarks=False,
                                      log_file_name=FLAGS.log_file_name,
                                      csv_log_file_name=FLAGS.csv_log_file_name,
                                      profile_file_name=FLAGS.profile_file_name)

--- a/pylot/operator_creator.py
+++ b/pylot/operator_creator.py
@@ -433,6 +433,7 @@ def add_fusion(can_bus_stream, obstacles_stream, depth_stream,
 
 def add_mpc_agent(can_bus_stream, waypoints_stream):
     op_config = erdos.OperatorConfig(name='mpc_agent_operator',
+                                     flow_watermarks=False,
                                      log_file_name=FLAGS.log_file_name,
                                      csv_log_file_name=FLAGS.csv_log_file_name,
                                      profile_file_name=FLAGS.profile_file_name)

--- a/pylot/planning/frenet_optimal_trajectory/fot_planning_operator.py
+++ b/pylot/planning/frenet_optimal_trajectory/fot_planning_operator.py
@@ -35,7 +35,6 @@ class FOTPlanningOperator(erdos.Operator):
                  can_bus_stream,
                  prediction_stream,
                  waypoints_stream,
-                 name,
                  flags,
                  goal_location,
                  log_file_name=None,

--- a/pylot/utils.py
+++ b/pylot/utils.py
@@ -327,7 +327,7 @@ class Transform(object):
                                                                           0])
             pitch_r = math.asin(self.forward_vector.z)
             yaw_r = math.acos(np.clip(
-                self.forward_vector.x / math.cos(pitch_r), 0, 1))
+                self.forward_vector.x / math.cos(pitch_r), -1, 1))
             roll_r = math.asin(matrix[2, 1] / (-1 * math.cos(pitch_r)))
             self.rotation = Rotation(math.degrees(pitch_r),
                                      math.degrees(yaw_r), math.degrees(roll_r))

--- a/pylot/utils.py
+++ b/pylot/utils.py
@@ -326,7 +326,8 @@ class Transform(object):
                                            self.matrix[1, 0], self.matrix[2,
                                                                           0])
             pitch_r = math.asin(self.forward_vector.z)
-            yaw_r = math.acos(self.forward_vector.x / math.cos(pitch_r))
+            yaw_r = math.acos(np.clip(
+                self.forward_vector.x / math.cos(pitch_r), 0, 1))
             roll_r = math.asin(matrix[2, 1] / (-1 * math.cos(pitch_r)))
             self.rotation = Rotation(math.degrees(pitch_r),
                                      math.degrees(yaw_r), math.degrees(roll_r))


### PR DESCRIPTION
Adding `flow_watermarks=False` in the PID agent operator creator fixed the following issue:
```
Traceback (most recent call last):
  File "/home/edward/Desktop/erdos/python/erdos/__init__.py", line 175, in internal_watermark_callback
    callback(timestamp, *write_streams)
  File "/home/edward/Desktop/erdos/python/erdos/__init__.py", line 185, in _flow_watermark_callback
    write_stream.send(WatermarkMessage(timestamp))
  File "/home/edward/Desktop/erdos/python/erdos/streams.py", line 130, in send
    return self._py_write_stream.send(internal_msg)
Exception: Error sending message on ingest stream fd04598a-4590-b39f-1db1-065697be09e1: TimestampError
```

To solve the math domain error when computing rotations in `Transform`, added a `np.clip(..., 0, 1)`. I verified that the values were indeed extremely close to 1, ie. 1.0000000000002.