### PR TITLE
Adds metrics for control evaluation.

### DIFF
--- a/pylot/component_creator.py
+++ b/pylot/component_creator.py
@@ -453,4 +453,8 @@ def add_control(can_bus_stream, waypoints_stream):
     else:
         raise ValueError('Unexpected control_agent {}'.format(
             FLAGS.control_agent))
+
+    if FLAGS.evaluate_control:
+        pylot.operator_creator.add_control_evaluation(can_bus_stream,
+                                                      waypoints_stream)
     return control_stream

--- a/pylot/control/control_eval_operator.py
+++ b/pylot/control/control_eval_operator.py
@@ -1,0 +1,160 @@
+import numpy as np
+from collections import deque
+from itertools import islice
+
+import erdos
+from pylot.utils import time_epoch_ms
+
+
+class ControlEvalOperator(erdos.Operator):
+    """ Operator that computes the accuracy metrics using reference waypoints
+    and the achieved waypoints.
+
+    Args:
+       can_bus_stream (:py:class:`erdos.ReadStream`): The stream on which the
+           vehicle transform is received.
+        waypoints_stream (:py:class:`erdos.ReadStream`): The stream on which
+           the waypoints are received from the planner.
+        flags (absl.flags): Object to be used to access absl flags.
+    """
+
+    def __init__(self, can_bus_stream, waypoints_stream, flags):
+        # Register callbacks to retrieve data from the CAN bus message and the
+        # waypoint message.
+        can_bus_stream.add_callback(self.on_can_bus_update)
+        waypoints_stream.add_callback(self.on_waypoint_update)
+
+        # Add a watermark callback on CAN bus stream and waypoints stream.
+        erdos.add_watermark_callback([can_bus_stream, waypoints_stream], [],
+                                     self.on_watermark)
+
+        # Initialize state.
+        self._logger = erdos.utils.setup_logging(self.config.name,
+                                                 self.config.log_file_name)
+        self._csv_logger = erdos.utils.setup_csv_logging(
+            self.config.name + '-csv', self.config.csv_log_file_name)
+        self._flags = flags
+        self._waypoints = deque()
+        self._can_bus_messages = deque()
+
+        # Keep track of the last 2 waypoints that the ego vehicle was
+        # supposed to achieve.
+        self.last_waypoints = deque(maxlen=2)
+
+    @staticmethod
+    def connect(can_bus_stream, waypoints_stream):
+        # This operator does not have any write streams.
+        return []
+
+    def on_can_bus_update(self, msg):
+        """ Callback function for the CAN bus update messages.
+
+        This function appends the received message to the operator state.
+
+        Args:
+            msg (:py:class:`erdos.Message`): The message contains an instance
+                of :py:class:`pylot.utils.CanBus`.
+        """
+        self._logger.debug('@{}: can bus update.'.format(msg.timestamp))
+        self._can_bus_messages.append(msg)
+
+    def on_waypoint_update(self, msg):
+        """ Callback function for the waypoint update messages.
+
+        This function appends the received message to the operator state.
+
+        Args:
+            msg (:py:class:`pylot.planning.messages.WaypointsMessage`): The
+                message contains the waypoints for the future trajectory, as
+                computed by the planner.
+        """
+        self._logger.debug('@{}: waypoints update.'.format(msg.timestamp))
+        self._waypoints.append(msg)
+
+    @erdos.profile_method()
+    def on_watermark(self, timestamp):
+        """ Computes and logs the metrics of accuracy for the control module.
+
+        This operator uses two different metrics of accuracy, as follows:
+            1. Crosstrack error: The distance between the waypoint that the
+                planner intended the vehicle to achieve, and the location
+                achieved by the control module.
+            2. Heading error: The angle between the heading of the vehicle,
+                and the reference trajectory that the planner intended the
+                vehicle to follow.
+
+        The log format is (timestamp, crosstrack_error, heading_error).
+
+        Args:
+            timestamp (:py:class:`erdos.timestamp.Timestamp`): The timestamp
+                of the watermark.
+        """
+        self._logger.debug('@{}: received watermark.'.format(timestamp))
+
+        # Get the transform of the ego vehicle.
+        can_bus_msg = self._can_bus_messages.popleft()
+        vehicle_transform = can_bus_msg.data.transform
+
+        if len(self.last_waypoints) == 2:
+            # Compute the metrics of accuracy using the last two waypoints.
+            self._logger.debug(
+                "@{}: vehicle location: {}, waypoints: {}".format(
+                    timestamp, vehicle_transform.location,
+                    self.last_waypoints))
+            crosstrack_err, heading_err = ControlEvalOperator.\
+                    compute_control_metrics(vehicle_transform,
+                            self.last_waypoints)
+
+            self._csv_logger.info("{}, {}, {}".format(time_epoch_ms(),
+                                                      crosstrack_err,
+                                                      heading_err))
+
+        # Add the first waypoint from the last waypoints received
+        # by the operator.
+        waypoints = self._waypoints.popleft().waypoints
+        next_waypoint = waypoints.popleft()
+        while len(self.last_waypoints) >= 1 and np.isclose(
+                next_waypoint.location.distance(
+                    self.last_waypoints[-1].location), 0.0):
+            next_waypoint = waypoints.popleft()
+        self.last_waypoints.append(next_waypoint)
+
+    @staticmethod
+    def compute_control_metrics(vehicle_transform, reference_waypoints):
+        """ Compute the metrics of accuracy for the control module.
+
+        Args:
+            vehicle_transform (:py:class:`pylot.utils.Transform`): The
+                transform of the vehicle.
+            reference_waypoints (:py:class:`tuple`): A tuple of two reference
+                waypoints.
+
+        Returns:
+            A tuple of (crosstrack_error, heading_error), as defined in the
+            on_watermark function.
+        """
+        if len(reference_waypoints) != 2:
+            raise ValueError("Expected 2 reference waypoints, got {}".format(
+                len(reference_waypoints)))
+
+        old_point, new_point = reference_waypoints
+
+        # Calculate the crosstrack error.
+        crosstrack_error = vehicle_transform.location.distance(
+            new_point.location)
+
+        # Calculate the heading error.
+        vehicle_forward_vector=vehicle_transform.forward_vector.\
+                as_numpy_array()
+
+        # Create a unit vector between the two reference waypoints.
+        waypoint_vector=new_point.location.as_numpy_array() - \
+                old_point.location.as_numpy_array()
+        waypoint_vector = waypoint_vector / np.linalg.norm(waypoint_vector)
+
+        # Get the angle between the two vectors.
+        heading_error = np.arccos(
+            np.clip(np.dot(waypoint_vector, vehicle_forward_vector), -1.0,
+                    1.0))
+
+        return (crosstrack_error, heading_error)

--- a/pylot/flags.py
+++ b/pylot/flags.py
@@ -125,6 +125,8 @@ flags.DEFINE_bool('evaluate_obstacle_tracking', False,
                   'True to enable object tracking evaluation')
 flags.DEFINE_bool('evaluate_prediction', False,
                   'True to enable prediction evaluation')
+flags.DEFINE_bool('evaluate_control', False,
+                  'True to enable control evaluation')
 flags.DEFINE_bool('evaluate_fusion', False, 'True to enable fusion evaluation')
 flags.DEFINE_bool('evaluate_segmentation', False,
                   'True to enable segmentation evaluation')

--- a/pylot/operator_creator.py
+++ b/pylot/operator_creator.py
@@ -180,6 +180,18 @@ def add_detection_evaluation(obstacles_stream,
                   [obstacles_stream, ground_obstacles_stream], FLAGS)
 
 
+def add_control_evaluation(can_bus_stream,
+                           waypoints_stream,
+                           name='control_eval_operator'):
+    from pylot.control.control_eval_operator import ControlEvalOperator
+    op_config = erdos.OperatorConfig(name=name,
+                                     log_file_name=FLAGS.log_file_name,
+                                     csv_log_file_name=FLAGS.csv_log_file_name,
+                                     profile_file_name=FLAGS.profile_file_name)
+    erdos.connect(ControlEvalOperator, op_config,
+                  [can_bus_stream, waypoints_stream], FLAGS)
+
+
 def add_traffic_light_detector(traffic_light_camera_stream):
     op_config = erdos.OperatorConfig(name='traffic_light_detector_operator',
                                      log_file_name=FLAGS.log_file_name,


### PR DESCRIPTION
Implements two metrics for control evaluation:
1. Crosstrack error : Difference between the desired and achieved waypoint.
2. Heading error: Angle between the heading of the vehicle and the heading desired by the reference waypoints.

The metrics were discussed [here](https://www.coursera.org/lecture/intro-self-driving-cars/lesson-1-introduction-to-lateral-vehicle-control-pTs75).