### PR TITLE
adding planning type to rrt conf

### DIFF
--- a/configs/scenarios/eval_person_avoidance_rrt.conf
+++ b/configs/scenarios/eval_person_avoidance_rrt.conf
@@ -27,6 +27,8 @@
 --prediction_type=linear
 --prediction_num_past_steps=10
 --prediction_num_future_steps=10
+######### Planning config #########
+--planning_type=rrt_star
 ###### Control config #####
 --noavoidance_agent
 --control_agent=pid


### PR DESCRIPTION
This was missing from the `eval_person_avoidance_rrt.conf`