### PR TITLE
Tracking allow missed detections

### DIFF
--- a/configs/scenarios/tracker_evaluation.conf
+++ b/configs/scenarios/tracker_evaluation.conf
@@ -14,6 +14,7 @@
 ###### Tracking config #####
 --obstacle_tracking
 --evaluate_obstacle_tracking
+--min_matching_iou=0.3
 --tracker_type=deep_sort
 #--tracker_type=sort
 #--tracker_type=da_siam_rpn

--- a/pylot/perception/tracking/da_siam_rpn_tracker.py
+++ b/pylot/perception/tracking/da_siam_rpn_tracker.py
@@ -10,7 +10,7 @@ from DaSiamRPN.code.run_SiamRPN import SiamRPN_init, SiamRPN_track
 from pylot.perception.detection.utils import BoundingBox2D, DetectedObstacle
 from pylot.perception.tracking.multi_object_tracker import MultiObjectTracker
 
-MAX_MISSED_DETECTIONS = 2
+MAX_MISSED_DETECTIONS = 5
 
 
 class SingleObjectDaSiamRPNTracker(object):
@@ -115,7 +115,7 @@ class MultiObjectDaSiamRPNTracker(MultiObjectTracker):
         # Add 1 to age of any unmatched trackers, filter old ones.
         for tracker in unmatched_trackers:
             tracker.missed_det_updates += 1
-            if tracker.missed_det_updates < MAX_MISSED_DETECTIONS:
+            if tracker.missed_det_updates <= MAX_MISSED_DETECTIONS:
                 updated_trackers.append(tracker)
             else:
                 self._logger.debug("Dropping tracker with id {}".format(

--- a/pylot/perception/tracking/da_siam_rpn_tracker.py
+++ b/pylot/perception/tracking/da_siam_rpn_tracker.py
@@ -66,7 +66,7 @@ class MultiObjectDaSiamRPNTracker(MultiObjectTracker):
         self._min_matching_iou = flags.min_matching_iou
 
     def initialize(self, frame, obstacles):
-        """ Reinitializes a multiple obstacle tracker.
+        """ Initializes a multiple obstacle tracker.
 
         Args:
             frame: perception.camera_frame.CameraFrame to reinitialize with.
@@ -78,37 +78,41 @@ class MultiObjectDaSiamRPNTracker(MultiObjectTracker):
                 SingleObjectDaSiamRPNTracker(frame, obstacle, self._siam_net))
 
     def reinitialize(self, frame, obstacles):
+        """ Renitializes a multiple obstacle tracker.
+
+        Args:
+            frame: perception.camera_frame.CameraFrame to reinitialize with.
+            obstacles: List of perception.detection.utils.DetectedObstacle.
+        """
+        # If empty obstacles passed in, continue existing tracks and exit.
+        if not obstacles:
+            self.track(frame)
+            return
+
         if self._trackers == []:
             self.initialize(frame, obstacles)
         # Create matrix of similarities between detection and tracker bboxes.
         cost_matrix = self._create_hungarian_cost_matrix(
             frame.frame, obstacles)
-        # Run linear assignment (Hungarian Algo) with matrix
+        # Run linear assignment (Hungarian Algo) with matrix.
         row_ids, col_ids = solve_dense(cost_matrix)
         matched_obstacle_indices, matched_tracker_indices = set(row_ids), set(
             col_ids)
 
         updated_trackers = []
-        # Separate matched and unmatched tracks
-        unmatched_tracker_indices = \
-            set(range(len(self._trackers))) - matched_tracker_indices
-        matched_trackers = [self._trackers[i] for i in matched_tracker_indices]
-        unmatched_trackers = [
-            self._trackers[i] for i in unmatched_tracker_indices
-        ]
-        # Separate matched and unmatched detections
-        unmatched_obstacle_indices = \
-            set(range(len(obstacles))) - matched_obstacle_indices
-        matched_obstacles = [obstacles[i] for i in matched_obstacle_indices]
-        unmatched_obstacles = [
-            obstacles[i] for i in unmatched_obstacle_indices
-        ]
+        # Separate matched and unmatched tracks, obstacles.
+        unmatched_tracker_indices, matched_trackers, unmatched_trackers = \
+            self._separate_matches_from_unmatched(self._trackers,
+                                                  matched_tracker_indices)
+        unmatched_obstacle_indices, matched_obstacles, unmatched_obstacles = \
+            self._separate_matches_from_unmatched(obstacles,
+                                                  matched_obstacle_indices)
 
-        # Add successfully matched trackers to updated_trackers
+        # Add successfully matched trackers to updated_trackers.
         for tracker in matched_trackers:
             tracker.missed_det_updates = 0
             updated_trackers.append(tracker)
-        # Add 1 to age of any unmatched trackers, filter old ones
+        # Add 1 to age of any unmatched trackers, filter old ones.
         for tracker in unmatched_trackers:
             tracker.missed_det_updates += 1
             if tracker.missed_det_updates < MAX_MISSED_DETECTIONS:
@@ -116,11 +120,11 @@ class MultiObjectDaSiamRPNTracker(MultiObjectTracker):
             else:
                 self._logger.debug("Dropping tracker with id {}".format(
                     tracker.obstacle.id))
-
+        # Initialize trackers for unmatched obstacles.
         for obstacle in unmatched_obstacles:
             updated_trackers.append(
                 SingleObjectDaSiamRPNTracker(frame, obstacle, self._siam_net))
-
+        # Keep one tracker per obstacle id; prefer trackers with recent detection updates.
         unique_updated_trackers = {}
         for tracker in updated_trackers:
             if tracker.obstacle.id not in unique_updated_trackers:
@@ -129,6 +133,18 @@ class MultiObjectDaSiamRPNTracker(MultiObjectTracker):
                 unique_updated_trackers[tracker.obstacle.id] = tracker
 
         self._trackers = list(unique_updated_trackers.values())
+
+    def track(self, frame):
+        """ Tracks obstacles in a frame.
+
+        Args:
+            frame: perception.camera_frame.CameraFrame to track in.
+        """
+        tracked_obstacles = []
+        for tracker in self._trackers:
+            tracked_obstacles.append(tracker.track(frame))
+            tracker.missed_det_updates += 1
+        return True, tracked_obstacles
 
     def _create_hungarian_cost_matrix(self, frame, obstacles):
         # Create cost matrix with shape (num_bboxes, num_trackers)
@@ -145,3 +161,12 @@ class MultiObjectDaSiamRPNTracker(MultiObjectTracker):
                 else:
                     cost_matrix[i][j] = np.nan
         return np.array(cost_matrix)
+
+    def _separate_matches_from_unmatched(self, obstacles, matched_obstacle_indices):
+        unmatched_obstacle_indices = \
+            set(range(len(obstacles))) - matched_obstacle_indices
+        matched_obstacles = [obstacles[i] for i in matched_obstacle_indices]
+        unmatched_obstacles = [
+            obstacles[i] for i in unmatched_obstacle_indices
+        ]
+        return unmatched_obstacle_indices, matched_obstacles, unmatched_obstacles

--- a/pylot/perception/tracking/deep_sort_tracker.py
+++ b/pylot/perception/tracking/deep_sort_tracker.py
@@ -38,8 +38,8 @@ class MultiObjectDeepSORTTracker(MultiObjectTracker):
                 labels.append(obstacle.label)
                 confidence_scores.append(obstacle.confidence)
                 ids.append(obstacle.id)
-                self._deepsort.run_deep_sort(
-                    frame.frame, confidence_scores, bboxes, labels, ids)
+            self._deepsort.run_deep_sort(
+                frame.frame, confidence_scores, bboxes, labels, ids)
         else:
             for track in self._deepsort.tracker.tracks:
                 if track.is_confirmed():

--- a/pylot/perception/tracking/deep_sort_tracker.py
+++ b/pylot/perception/tracking/deep_sort_tracker.py
@@ -46,14 +46,13 @@ class MultiObjectDeepSORTTracker(MultiObjectTracker):
                     track.predict(self._deepsort.tracker.kf)
         tracked_obstacles = []
         for track in self._deepsort.tracker.tracks:
-            if not track.is_confirmed() or track.time_since_update > 1:
-                continue
-            # Converts x, y, w, h bbox to tlbr bbox (top left and bottom
-            # right coords).
-            bbox = track.to_tlbr()
-            # Converts to xmin, xmax, ymin, ymax format.
-            bbox_2d = BoundingBox2D(int(bbox[0]), int(bbox[2]), int(bbox[1]),
-                                    int(bbox[3]))
-            tracked_obstacles.append(
-                DetectedObstacle(bbox_2d, 0, track.label, track.track_id))
+            if track.is_confirmed():
+                # Converts x, y, w, h bbox to tlbr bbox (top left and bottom
+                # right coords).
+                bbox = track.to_tlbr()
+                # Converts to xmin, xmax, ymin, ymax format.
+                bbox_2d = BoundingBox2D(int(bbox[0]), int(bbox[2]), int(bbox[1]),
+                                        int(bbox[3]))
+                tracked_obstacles.append(
+                    DetectedObstacle(bbox_2d, 0, track.label, track.track_id))
         return True, tracked_obstacles

--- a/pylot/perception/tracking/sort_tracker.py
+++ b/pylot/perception/tracking/sort_tracker.py
@@ -8,7 +8,7 @@ from pylot.perception.tracking.multi_object_tracker import MultiObjectTracker
 
 class MultiObjectSORTTracker(MultiObjectTracker):
     def __init__(self, flags):
-        self.tracker = Sort(min_iou=flags.min_matching_iou)
+        self.tracker = Sort(min_hits=1, min_iou=flags.min_matching_iou)
 
     def reinitialize(self, frame, obstacles):
         """ Reinitializes a multiple obstacle tracker.


### PR DESCRIPTION
- Trackers should all track properly, even when an empty obstacles message is received.
- Trackers all use the same default hyperparameters (min/max matching iou threshold, max tracker age, etc.)
- Fixed a deepsort bug that resulted in too many updates, lowering mota unecessarily