### PR TITLE
Updating person crossing and person avoidance config

### DIFF
--- a/configs/scenarios/person_avoidance_frenet.conf
+++ b/configs/scenarios/person_avoidance_frenet.conf
@@ -13,21 +13,19 @@
 --prediction
 --prediction_type=linear
 --prediction_num_past_steps=5
---prediction_num_future_steps=5
+--prediction_num_future_steps=10
 ######### Planning config #########
 --planning_type=frenet_optimal_trajectory
 --target_speed=20
 --max_speed=35
---obstacle_radius=2.0
---d_road_w=0.2
+--obstacle_radius=1.0
+--d_road_w=0.1
 --dt=0.1
 --maxt=5.0
 --mint=2.0
+--ko=50
 --max_curvature=4.0
 --max_accel=10.0
---steer_gain=1.0
---pid_steer_wp=5
---pid_speed_wp=-1
 --max_road_width_l=6.0
 --num_waypoints_ahead=30
 --goal_location=17.73, 327.07, 0.5
@@ -37,6 +35,9 @@
 --stop_for_vehicles=False
 --stop_for_people=False
 --stop_for_traffic_lights=False
+--steer_gain=1.0
+--pid_steer_wp=5
+--pid_speed_wp=-1
 ###### Evaluation #####
 --evaluation
 ######### Logging config #########

--- a/configs/scenarios/person_crossing_frenet.conf
+++ b/configs/scenarios/person_crossing_frenet.conf
@@ -16,16 +16,17 @@
 --prediction
 --prediction_type=linear
 --prediction_num_past_steps=5
---prediction_num_future_steps=5
+--prediction_num_future_steps=10
 ######### Frenet Planning config #########
 --planning_type=frenet_optimal_trajectory
 --target_speed=20
 --max_speed=35
---obstacle_radius=1.75
---d_road_w=0.2
+--obstacle_radius=1
+--d_road_w=0.1
 --dt=0.1
---maxt=6.0
+--maxt=5.0
 --mint=2.0
+--ko=50
 --max_curvature=4.0
 --max_accel=10.0
 --steer_gain=1.0

--- a/configs/scenarios/person_crossing_frenet.conf
+++ b/configs/scenarios/person_crossing_frenet.conf
@@ -29,18 +29,18 @@
 --ko=50
 --max_curvature=4.0
 --max_accel=10.0
---steer_gain=1.0
---pid_steer_wp=10
---pid_speed_wp=-1
 --max_road_width_l=6.0
 --num_waypoints_ahead=30
+--goal_location=87.73, 327.07, 0.5
 ######### Control config #########
 --control_agent=pid
 --noavoidance_agent
 --stop_for_vehicles=False
 --stop_for_people=False
 --stop_for_traffic_lights=False
---goal_location=87.73, 327.07, 0.5
+--steer_gain=1.0
+--pid_steer_wp=10
+--pid_speed_wp=-1
 ###### Evaluation #####
 --evaluation
 ######### Logging config #########


### PR DESCRIPTION
Obstacle radius was too penalizing, causing frenet to fail when it could have found a solution. We can get around this by using the inverse distance to obstacle cost, `ko`, and increasing the prediction steps.