### PR TITLE
Added multi-agent support to R2P2

### DIFF
--- a/pylot/component_creator.py
+++ b/pylot/component_creator.py
@@ -378,12 +378,10 @@ def add_prediction(obstacles_tracking_stream,
             prediction_stream = pylot.operator_creator.add_linear_prediction(
                 obstacles_tracking_stream)
         elif FLAGS.prediction_type == 'r2p2':
-            assert pose_stream is not None
             assert point_cloud_stream is not None
             assert lidar_setup is not None
             prediction_stream = pylot.operator_creator.add_r2p2_prediction(
-                pose_stream, point_cloud_stream, obstacles_tracking_stream,
-                vehicle_id_stream, lidar_setup)
+                point_cloud_stream, obstacles_tracking_stream, lidar_setup)
         else:
             raise ValueError('Unexpected prediction_type {}'.format(
                 FLAGS.prediction_type))

--- a/pylot/operator_creator.py
+++ b/pylot/operator_creator.py
@@ -312,8 +312,7 @@ def add_linear_prediction(tracking_stream):
     return prediction_stream
 
 
-def add_r2p2_prediction(pose_stream, point_cloud_stream,
-                        obstacles_tracking_stream, vehicle_id_stream,
+def add_r2p2_prediction(point_cloud_stream, obstacles_tracking_stream,
                         lidar_setup):
     from pylot.prediction.r2p2_predictor_operator import \
             R2P2PredictorOperator
@@ -321,10 +320,8 @@ def add_r2p2_prediction(pose_stream, point_cloud_stream,
                                      log_file_name=FLAGS.log_file_name,
                                      csv_log_file_name=FLAGS.csv_log_file_name,
                                      profile_file_name=FLAGS.profile_file_name)
-    [prediction_stream] = erdos.connect(R2P2PredictorOperator, op_config, [
-        pose_stream, point_cloud_stream, obstacles_tracking_stream,
-        vehicle_id_stream
-    ], FLAGS, lidar_setup)
+    [prediction_stream] = erdos.connect(R2P2PredictorOperator, op_config,
+        [point_cloud_stream, obstacles_tracking_stream], FLAGS, lidar_setup)
     return prediction_stream
 
 

--- a/pylot/planning/utils.py
+++ b/pylot/planning/utils.py
@@ -137,6 +137,11 @@ def stop_vehicle(ego_transform, obstacle, wp_vector, flags, logger, hd_map):
     Returns:
         :obj:`float`: A stopping factor between 0 and 1 (i.e., no braking).
     """
+    if ego_transform.location.x == obstacle.transform.location.x and \
+       ego_transform.location.y == obstacle.transform.location.y and \
+       ego_transform.location.z == obstacle.transform.location.z:
+        # Don't stop for ourselves.
+        return 1
     if hd_map is not None:
         if not hd_map.are_on_same_lane(ego_transform.location,
                                        obstacle.transform.location):

--- a/pylot/prediction/flags.py
+++ b/pylot/prediction/flags.py
@@ -6,6 +6,12 @@ flags.DEFINE_integer(
 flags.DEFINE_integer(
     'prediction_num_future_steps', None,
     'Number of future steps outputted by the prediction module.')
+flags.DEFINE_integer(
+    'prediction_radius', 50,
+    'Make predictions for all vehicles within this radius of the ego-vehicle.')
+flags.DEFINE_boolean(
+    'prediction_ego_agent', True,
+    'Whether we make predictions for the ego agent')
 
 # R2P2 Flags
 flags.DEFINE_string('r2p2_model_path',

--- a/pylot/prediction/flags.py
+++ b/pylot/prediction/flags.py
@@ -10,7 +10,7 @@ flags.DEFINE_integer(
     'prediction_radius', 50,
     'Make predictions for all vehicles within this radius of the ego-vehicle.')
 flags.DEFINE_boolean(
-    'prediction_ego_agent', True,
+    'prediction_ego_agent', False,
     'Whether we make predictions for the ego agent')
 
 # R2P2 Flags

--- a/pylot/prediction/r2p2_predictor_operator.py
+++ b/pylot/prediction/r2p2_predictor_operator.py
@@ -280,7 +280,7 @@ class R2P2PredictorOperator(erdos.Operator):
         # coordinates but with the y- and z-coordinates negated (for
         # a reference describing PRECOG coordinates, see e.g. https://github.com/nrhine1/deep_imitative_models/blob/0d52edfa54cb79da28bd7cf965ebccbe8514fc10/dim/env/preprocess/carla_preprocess.py#L584)
         to_precog_transform = Transform(matrix=np.array(
-            [[1, 0, 0, 0], [0, 0, -1, 0], [0, -1, 0, 0], [0, 0, 0, 1]]))
+            [[1, 0, 0, 0], [0, 0, 1, 0], [0, -1, 0, 0], [0, 0, 0, 1]]))
         transformed_point_cloud = to_precog_transform.transform_points(
             point_cloud)
         return transformed_point_cloud

--- a/pylot/simulation/perfect_tracker_operator.py
+++ b/pylot/simulation/perfect_tracker_operator.py
@@ -64,12 +64,7 @@ class PerfectTrackerOperator(erdos.Operator):
                 # box, in relation to the Pose measurement.
                 v_transform = past_obstacle_loc.transform * \
                                 past_obstacle_loc.bounding_box.transform
-                #new_location = pose_transform.inverse_transform_locations(
-                #    [v_transform.location])[0]
                 new_transform = pose_transform.inverse_transform() * v_transform
-                #cur_obstacle_trajectory.append(
-                #    pylot.utils.Transform(location=new_location,
-                #                          rotation=pylot.utils.Rotation()))
                 cur_obstacle_trajectory.append(new_transform)
             obstacle_trajectories.append(
                 ObstacleTrajectory(obstacle.label, obstacle.id,

--- a/pylot/simulation/perfect_tracker_operator.py
+++ b/pylot/simulation/perfect_tracker_operator.py
@@ -60,15 +60,17 @@ class PerfectTrackerOperator(erdos.Operator):
             cur_obstacle_trajectory = []
             # Iterate through past frames of this obstacle.
             for past_obstacle_loc in self._obstacles[obstacle.id]:
-                # Get the location of the center of the obstacle's bounding
+                # Get the transform of the center of the obstacle's bounding
                 # box, in relation to the Pose measurement.
                 v_transform = past_obstacle_loc.transform * \
                                 past_obstacle_loc.bounding_box.transform
-                new_location = pose_transform.inverse_transform_locations(
-                    [v_transform.location])[0]
-                cur_obstacle_trajectory.append(
-                    pylot.utils.Transform(location=new_location,
-                                          rotation=pylot.utils.Rotation()))
+                #new_location = pose_transform.inverse_transform_locations(
+                #    [v_transform.location])[0]
+                new_transform = pose_transform.inverse_transform() * v_transform
+                #cur_obstacle_trajectory.append(
+                #    pylot.utils.Transform(location=new_location,
+                #                          rotation=pylot.utils.Rotation()))
+                cur_obstacle_trajectory.append(new_transform)
             obstacle_trajectories.append(
                 ObstacleTrajectory(obstacle.label, obstacle.id,
                                    obstacle.bounding_box,

--- a/pylot/utils.py
+++ b/pylot/utils.py
@@ -605,6 +605,11 @@ class Transform(object):
             return False
         return d_angle < 90.0
 
+    def inverse_transform(self):
+        """Returns the inverse transform of this transform."""
+        new_matrix = np.linalg.inv(self.matrix)
+        return Transform(matrix=new_matrix)
+
     def __mul__(self, other):
         new_matrix = np.dot(self.matrix, other.matrix)
         return Transform(matrix=new_matrix)


### PR DESCRIPTION
Extends R2P2 to the multi-agent case, outputting predictions for all vehicles within a specified radius. 

For each vehicle, the operator rotates the ego-vehicle's LIDAR point cloud, as well as the vehicle's past trajectory, to that vehicle's coordinate frame before performing inference. Orientations of vehicles are estimated using the past two locations of the vehicle. R2P2 inherently does not perform any joint modeling of agents.