### PR TITLE
Fix MPC bugs

### DIFF
--- a/pylot/control/mpc/mpc.py
+++ b/pylot/control/mpc/mpc.py
@@ -237,7 +237,7 @@ class ModelPredictiveController:
                 reference_steer[0, t])
             constraints += [
                 x[:,
-                  t + 1] == matrix_a * x[:, t] + matrix_b * u[:, t] + matrix_c
+                  t + 1] == matrix_a @ x[:, t] + matrix_b @ u[:, t] + matrix_c
             ]
 
             if t < (self.config['horizon'] - 1):


### PR DESCRIPTION
- MPCOperator used `self._config` which is reserved by the `OperatorConfig`, causing errors with the logging.
- Make MPC use the latest waypoint APIs which also fixes some errors.
- Use `@` instead of `*` for cvxpy matrix multiplication to suppress warning messages.