### PR TITLE
[mAP computation] Fix error when confidences are equal, and condensed code

### DIFF
--- a/pylot/perception/detection/utils.py
+++ b/pylot/perception/detection/utils.py
@@ -459,14 +459,10 @@ def get_precision_recall_at_iou(ground_truths, predictions, iou_threshold):
 
 def get_mAP(ground_obstacles, obstacles):
     """Return mAP with IoU threshold of 0.5"""
-    confidence_bbox = []
-    for obstacle in obstacles:
-        confidence_bbox.append(
-            (obstacle.confidence, obstacle._bounding_box_2D))
     # Sort bboxes descending by score.
-    confidence_bbox.sort()
-    confidence_bbox.reverse()
-    detected_bboxes = [bbox for (score, bbox) in confidence_bbox]
+    sorted_obstacles = \
+        sorted(obstacles, key=lambda o: o.confidence, reverse=True)
+    detected_bboxes = [o._bounding_box_2D for o in sorted_obstacles]
     ground_bboxes = [
         obstacle._bounding_box_2D for obstacle in ground_obstacles
     ]


### PR DESCRIPTION
Because tuples are sorted lexicographically, when the first entries in the tuples (confidence) are equal, the second entries (bbox objects) are compared. This leads to the following error:
```
Traceback (most recent call last):
  File "/home/eyal/.local/lib/python3.6/site-packages/erdos/__init__.py", line 195, in internal_watermark_callback
    callback(timestamp, *write_streams)
  File "/home/eyal/pylot/pylot/perception/detection/detection_eval_operator.py", line 84, in on_watermark
    ground_obstacles, obstacles)
  File "/home/eyal/pylot/pylot/perception/detection/utils.py", line 467, in get_mAP
    confidence_bbox.sort()
TypeError: '<' not supported between instances of 'BoundingBox2D' and 'BoundingBox2D'
```

This fix achieves the same effect but gets around this issue.