### PR TITLE
perfect lane detection config

### DIFF
--- a/configs/perfect_lane_detection.conf
+++ b/configs/perfect_lane_detection.conf
@@ -1,0 +1,19 @@
+--perfect_lane_detection
+###### Control config #####
+--control=carla_auto_pilot
+######### Carla config #########
+--carla_num_people=50
+--carla_num_vehicles=20
+# Resolution required by lanenet.
+--camera_image_width=1280
+--camera_image_height=720
+# Resolution required by Canny edge lane detetection.
+# --camera_image_width=800
+# --camera_image_height=600
+######### Logging config #########
+--log_file_name=pylot.log
+--csv_log_file_name=pylot.csv
+--v=1
+######### Other config #########
+--visualize_rgb_camera
+--visualize_detected_lanes

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -365,7 +365,9 @@ class HDMap(object):
     def get_all_lanes(self, location):
         lanes = [self.get_lane(location)]
 
-        waypoint = self._get_waypoint(location, project_to_road=False, lane_type=carla.LaneType.Any)
+        waypoint = self._get_waypoint(location,
+                                      project_to_road=False,
+                                      lane_type=carla.LaneType.Any)
         if waypoint:
             wp_left = waypoint.get_left_lane()
             w_rotation = waypoint.transform.rotation
@@ -387,7 +389,7 @@ class HDMap(object):
                 lanes.append(
                     self.get_lane(camera_transform_r.location,
                                   lane_id=wp_right.lane_id))
-                if  w_rotation == wp_right.transform.rotation:
+                if w_rotation == wp_right.transform.rotation:
                     wp_right = wp_right.get_right_lane()
                 else:
                     wp_right = wp_left.get_right_lane()

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -347,7 +347,7 @@ class HDMap(object):
         if waypoint:
             left_lane_waypoint = waypoint.get_left_lane()
             if left_lane_waypoint:
-                return pylot.utils.Transform.from_carla_transform(
+                return Transform.from_carla_transform(
                     left_lane_waypoint.transform)
         return None
 
@@ -358,7 +358,7 @@ class HDMap(object):
         if waypoint:
             right_lane_waypoint = waypoint.get_right_lane()
             if right_lane_waypoint:
-                return pylot.utils.Transform.from_carla_transform(
+                return Transform.from_carla_transform(
                     right_lane_waypoint.transform)
         return None
 
@@ -372,10 +372,10 @@ class HDMap(object):
             wp_left = waypoint.get_left_lane()
             w_rotation = waypoint.transform.rotation
             while wp_left and wp_left.lane_type == carla.LaneType.Driving:
-                camera_transform_l = pylot.utils.Transform.from_carla_transform(
+                camera_transform = Transform.from_carla_transform(
                     wp_left.transform)
                 lanes.append(
-                    self.get_lane(camera_transform_l.location,
+                    self.get_lane(camera_transform.location,
                                   lane_id=wp_left.lane_id))
                 if w_rotation == wp_left.transform.rotation:
                     wp_left = wp_left.get_left_lane()
@@ -384,10 +384,10 @@ class HDMap(object):
 
             wp_right = waypoint.get_right_lane()
             while wp_right and wp_right.lane_type == carla.LaneType.Driving:
-                camera_transform_r = pylot.utils.Transform.from_carla_transform(
+                camera_transform = Transform.from_carla_transform(
                     wp_right.transform)
                 lanes.append(
-                    self.get_lane(camera_transform_r.location,
+                    self.get_lane(camera_transform.location,
                                   lane_id=wp_right.lane_id))
                 if w_rotation == wp_right.transform.rotation:
                     wp_right = wp_right.get_right_lane()

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -395,7 +395,7 @@ class HDMap(object):
                 lanes.append(
                     self.get_lane(right_location, lane_id=wp_right.lane_id))
 
-                # Same logic as above. If right lane of current is in 
+                # Same logic as above. If right lane of current is in
                 # opposite direction, move rightwards by selecting it's
                 # left lane.
                 if w_rotation == wp_right.transform.rotation:

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -319,7 +319,9 @@ class HDMap(object):
 
     def get_lane(self, location: Location, waypoint_precision: float = 0.05):
         lane_waypoints = []
-        next_wp = [self._get_waypoint(location)]
+        next_wp = [self._get_waypoint(location,
+                                      project_to_road=False,
+                                      lane_type=carla.LaneType.Any)]
 
         while len(next_wp) == 1:
             lane_waypoints.append(next_wp[0])
@@ -334,7 +336,7 @@ class HDMap(object):
             self._lateral_shift(w.transform, w.lane_width * 0.5)
             for w in lane_waypoints
         ]
-        return Lane(left_markings, right_markings)
+        return Lane(0, left_markings, right_markings)
 
     def get_left_lane(self, location: Location):
         waypoint = self._get_waypoint(location, project_to_road=False)

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -341,7 +341,9 @@ class HDMap(object):
         return Lane(lane_id, left_markings, right_markings)
 
     def get_left_lane(self, location):
-        waypoint = self._get_waypoint(location, project_to_road=False, lane_type=carla.LaneType.Any)
+        waypoint = self._get_waypoint(location,
+                                      project_to_road=False,
+                                      lane_type=carla.LaneType.Any)
         if waypoint:
             left_lane_waypoint = waypoint.get_left_lane()
             if left_lane_waypoint:
@@ -350,7 +352,9 @@ class HDMap(object):
         return None
 
     def get_right_lane(self, location):
-        waypoint = self._get_waypoint(location, project_to_road=False, lane_type=carla.LaneType.Any)
+        waypoint = self._get_waypoint(location,
+                                      project_to_road=False,
+                                      lane_type=carla.LaneType.Any)
         if waypoint:
             right_lane_waypoint = waypoint.get_right_lane()
             if right_lane_waypoint:

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -317,7 +317,10 @@ class HDMap(object):
         else:
             return (False, None)
 
-    def get_lane(self, location: Location, waypoint_precision: float = 0.05, lane_id: int = 0):
+    def get_lane(self,
+                 location: Location,
+                 waypoint_precision: float = 0.05,
+                 lane_id: int = 0):
         lane_waypoints = []
         next_wp = [
             self._get_waypoint(location,
@@ -375,8 +378,7 @@ class HDMap(object):
                 left_location = Location.from_carla_location(
                     wp_left.transform.location)
                 lanes.append(
-                    self.get_lane(left_location,
-                                  lane_id=wp_left.lane_id))
+                    self.get_lane(left_location, lane_id=wp_left.lane_id))
 
                 # If left lane is facing the opposite direction, its left
                 # lane would point back to the current lane, so we select
@@ -391,8 +393,7 @@ class HDMap(object):
                 right_location = Location.from_carla_location(
                     wp_right.transform.location)
                 lanes.append(
-                    self.get_lane(right_location,
-                                  lane_id=wp_right.lane_id))
+                    self.get_lane(right_location, lane_id=wp_right.lane_id))
 
                 # Same logic as above. If right lane of current is in 
                 # opposite direction, move rightwards by selecting it's

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -319,9 +319,11 @@ class HDMap(object):
 
     def get_lane(self, location: Location, waypoint_precision: float = 0.05):
         lane_waypoints = []
-        next_wp = [self._get_waypoint(location,
-                                      project_to_road=False,
-                                      lane_type=carla.LaneType.Any)]
+        next_wp = [
+            self._get_waypoint(location,
+                               project_to_road=False,
+                               lane_type=carla.LaneType.Any)
+        ]
 
         while len(next_wp) == 1:
             lane_waypoints.append(next_wp[0])

--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -370,20 +370,23 @@ class HDMap(object):
             wp_left = waypoint.get_left_lane()
             w_rotation = waypoint.transform.rotation
             while wp_left and wp_left.lane_type == carla.LaneType.Driving:
-                camera_transform = pylot.utils.Transform.from_carla_transform(
+                camera_transform_l = pylot.utils.Transform.from_carla_transform(
                     wp_left.transform)
-                lanes.append(self.get_lane(camera_transform.location, lane_id=wp_left.lane_id))
+                lanes.append(
+                    self.get_lane(camera_transform_l.location,
+                                  lane_id=wp_left.lane_id))
                 if w_rotation == wp_left.transform.rotation:
                     wp_left = wp_left.get_left_lane()
                 else:
                     wp_left = wp_left.get_right_lane()
 
             wp_right = waypoint.get_right_lane()
-            w_rotation = waypoint.transform.rotation
             while wp_right and wp_right.lane_type == carla.LaneType.Driving:
-                camera_transform = pylot.utils.Transform.from_carla_transform(
+                camera_transform_r = pylot.utils.Transform.from_carla_transform(
                     wp_right.transform)
-                lanes.append(self.get_lane(camera_transform.location, lane_id=wp_right.lane_id))
+                lanes.append(
+                    self.get_lane(camera_transform_r.location,
+                                  lane_id=wp_right.lane_id))
                 if  w_rotation == wp_right.transform.rotation:
                     wp_right = wp_right.get_right_lane()
                 else:

--- a/pylot/simulation/perfect_lane_detector_operator.py
+++ b/pylot/simulation/perfect_lane_detector_operator.py
@@ -78,8 +78,9 @@ class PerfectLaneDetectionOperator(erdos.Operator):
             pose_msg.timestamp))
         vehicle_location = pose_msg.data.transform.location
         if self._map:
-            lanes = [self._map.get_lane(vehicle_location)]
-            lanes[0].draw_on_world(self._world)
+            lanes = self._map.get_all_lanes(vehicle_location)
+            for lane in lanes:
+                lane.draw_on_world(self._world)
         else:
             self._logger.debug('@{}: map is not ready yet'.format(
                 pose_msg.timestamp))


### PR DESCRIPTION
* Added lane detection config that uses the perfect lane detection operator with `--perfect_lane_detection` flag

These changes will fix the errors when using the perfect lane detection flag: 
* fixed some bugs with fetching lanes in `get_lane`  because of missing parameters.
* id in Lane output will be set to 0 by default in `get_lane`
* add ability to get all lanes using `get_all_lanes` function and the approach described in meetings
![image](https://user-images.githubusercontent.com/27945836/93661481-03977d80-fa0d-11ea-8776-1273297a9cfe.png)

