### PR TITLE
Fix pygame version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ open3d-python==0.5.0.0
 opencv-python>=4.1.0.25
 opencv-contrib-python>=4.1.0.25
 pillow>=6.2.2
-pygame
+pygame==1.9.6
 pytest
 scikit-image<0.15
 scipy==1.2.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "opencv-python>=4.1.0.25",
         "opencv-contrib-python>=4.1.0.25",
         "pillow>=6.2.2",
-        "pygame",
+        "pygame==1.9.6",
         "pytest",
         "scikit-image<0.15",
         "scipy==1.2.2",


### PR DESCRIPTION
Sets pygame version to `pygame==1.9.6`, as newer version of pygame cause errors with X errors in docker.

See #152 for more details on the errors.