### PR TITLE
eval min matching iou

### DIFF
--- a/pylot/perception/flags.py
+++ b/pylot/perception/flags.py
@@ -53,6 +53,9 @@ flags.DEFINE_integer(
 flags.DEFINE_float(
     'min_matching_iou', 0.5,
     'IoU required between detection and track for matching to be considered')
+flags.DEFINE_float(
+    'eval_min_matching_iou', 0.5,
+    'IoU required for tracking evaluation')
 flags.DEFINE_integer('obstacle_track_max_age', 3,
                      'Number of frames to track without a detection update')
 flags.DEFINE_integer(

--- a/pylot/perception/flags.py
+++ b/pylot/perception/flags.py
@@ -53,9 +53,8 @@ flags.DEFINE_integer(
 flags.DEFINE_float(
     'min_matching_iou', 0.5,
     'IoU required between detection and track for matching to be considered')
-flags.DEFINE_float(
-    'eval_min_matching_iou', 0.5,
-    'IoU required for tracking evaluation')
+flags.DEFINE_float('eval_min_matching_iou', 0.5,
+                   'IoU required for tracking evaluation')
 flags.DEFINE_integer('obstacle_track_max_age', 3,
                      'Number of frames to track without a detection update')
 flags.DEFINE_integer(

--- a/pylot/perception/tracking/tracking_eval_operator.py
+++ b/pylot/perception/tracking/tracking_eval_operator.py
@@ -76,8 +76,8 @@ class TrackingScoringModule(ScoringModule):
         tracked_bboxes = np.array([
             ob.bounding_box.as_width_height_bbox() for ob in tracked_obstacles
         ])
-        cost_matrix = mm.distances.iou_matrix(ground_bboxes,
-                                              tracked_bboxes,
-                                              max_iou=1 -
-                                              self._flags.min_matching_iou)
+        cost_matrix = mm.distances.iou_matrix(
+            ground_bboxes,
+            tracked_bboxes,
+            max_iou=1 - self._flags.eval_min_matching_iou)
         self.accumulator.update(ground_ids, track_ids, cost_matrix)


### PR DESCRIPTION
Decoupling the min IOU used by the tracker for ID matching between frames, versus the min IOU used by the tracking eval to match predictions with ground truth.