### PR TITLE
Organize logs into folders

### DIFF
--- a/pylot/flags.py
+++ b/pylot/flags.py
@@ -1,4 +1,5 @@
 from absl import flags
+import datetime
 
 import pylot.control.flags
 import pylot.debug.flags
@@ -146,12 +147,21 @@ flags.DEFINE_bool(
 flags.DEFINE_integer('top_down_camera_altitude', 40,
                      'Altitude of the top-down world camera (in meters).')
 
+
 ########################################
 # Recording operators.
 ########################################
+def get_default_data_path():
+    """Returns the default data path as data/<current_timestamp>."""
+    now = datetime.datetime.now()
+    now_str = now.isoformat(timespec='seconds')
+    return '{}/{}/'.format('data', now_str)
+
+
 flags.DEFINE_string('simulation_recording_file', None,
                     'Path to where the simulation is recorded')
-flags.DEFINE_string('data_path', 'data/', 'Path where to logged data')
+flags.DEFINE_string('data_path', get_default_data_path(),
+                    'Path where to logged data')
 flags.DEFINE_bool('log_detector_output', False,
                   'Enable recording of bbox annotated detector images')
 flags.DEFINE_bool('log_traffic_light_detector_output', False,

--- a/pylot/loggers/bounding_box_logger_operator.py
+++ b/pylot/loggers/bounding_box_logger_operator.py
@@ -18,6 +18,7 @@ class BoundingBoxLoggerOperator(erdos.Operator):
         _logger (:obj:`logging.Logger`): Instance to be used to log messages.
         _flags (absl.flags): Object to be used to access absl flags.
         _msg_cnt (:obj:`int`): Number of messages received.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, obstacles_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags):
@@ -26,6 +27,8 @@ class BoundingBoxLoggerOperator(erdos.Operator):
                                                  self.config.log_file_name)
         self._flags = flags
         self._msg_cnt = 0
+        self._data_path = os.path.join(self._flags.data_path, 'bboxes')
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(obstacles_stream: erdos.ReadStream):
@@ -54,7 +57,7 @@ class BoundingBoxLoggerOperator(erdos.Operator):
         assert len(msg.timestamp.coordinates) == 1
         timestamp = msg.timestamp.coordinates[0]
         # Write the bounding boxes.
-        file_name = os.path.join(self._flags.data_path,
+        file_name = os.path.join(self._data_path,
                                  'bboxes-{}.json'.format(timestamp))
         with open(file_name, 'w') as outfile:
             json.dump(bboxes, outfile)

--- a/pylot/loggers/camera_logger_operator.py
+++ b/pylot/loggers/camera_logger_operator.py
@@ -1,4 +1,5 @@
 """This module implements an operator that logs camera frames."""
+import os
 
 import erdos
 
@@ -19,6 +20,7 @@ class CameraLoggerOperator(erdos.Operator):
         _frame_cnt (:obj:`int`): Number of messages received.
         _filename_prefix (:obj:`str`): Used to construct the names of the files
             it logs to.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, camera_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags,
@@ -29,6 +31,8 @@ class CameraLoggerOperator(erdos.Operator):
         self._flags = flags
         self._frame_cnt = 0
         self._filename_prefix = filename_prefix
+        self._data_path = os.path.join(self._flags.data_path, filename_prefix)
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(camera_stream: erdos.ReadStream):
@@ -46,5 +50,5 @@ class CameraLoggerOperator(erdos.Operator):
         self._frame_cnt += 1
         if self._frame_cnt % self._flags.log_every_nth_message != 0:
             return
-        msg.frame.save(msg.timestamp.coordinates[0], self._flags.data_path,
+        msg.frame.save(msg.timestamp.coordinates[0], self._data_path,
                        self._filename_prefix)

--- a/pylot/loggers/chauffeur_logger_operator.py
+++ b/pylot/loggers/chauffeur_logger_operator.py
@@ -56,6 +56,8 @@ class ChauffeurLoggerOperator(erdos.Operator):
         self._current_transform = None
         self._previous_transform = None
         self._top_down_camera_setup = top_down_camera_setup
+        self._data_path = os.path.join(self._flags.data_path, 'chauffeur')
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(vehicle_id_stream: erdos.ReadStream,
@@ -137,7 +139,7 @@ class ChauffeurLoggerOperator(erdos.Operator):
         future_poses_img = Image.fromarray(future_poses)
         future_poses_img = future_poses_img.convert('RGB')
         file_name = os.path.join(
-            self._flags.data_path,
+            self.self._data_path,
             'future_poses-{}.png'.format(msg.timestamp.coordinates[0] -
                                          len(self._waypoints) * 100))
         future_poses_img.save(file_name)
@@ -145,7 +147,7 @@ class ChauffeurLoggerOperator(erdos.Operator):
         # Log future poses
         waypoints = [str(wp) for wp in self._waypoints]
         file_name = os.path.join(
-            self._flags.data_path,
+            self.self._data_path,
             'waypoints-{}.json'.format(msg.timestamp.coordinates[0] -
                                        len(self._waypoints) * 100))
         with open(file_name, 'w') as outfile:
@@ -155,15 +157,15 @@ class ChauffeurLoggerOperator(erdos.Operator):
         past_poses_img = Image.fromarray(past_poses)
         past_poses_img = past_poses_img.convert('RGB')
         file_name = os.path.join(
-            self._flags.data_path,
+            self.self._data_path,
             'past_poses-{}.png'.format(msg.timestamp.coordinates[0]))
         past_poses_img.save(file_name)
 
     def on_top_down_segmentation_update(self, msg: erdos.Message):
         assert len(msg.timestamp.coordinates) == 1
         # Save the segmented channels
-        msg.frame.save_per_class_masks(self._flags.data_path, msg.timestamp)
-        msg.frame.save(msg.timestamp.coordinates[0], self._flags.data_path,
+        msg.frame.save_per_class_masks(self.self._data_path, msg.timestamp)
+        msg.frame.save(msg.timestamp.coordinates[0], self.self._data_path,
                        'top_down_segmentation')
 
     def on_ground_vehicle_id_update(self, msg: erdos.Message):
@@ -180,14 +182,14 @@ class ChauffeurLoggerOperator(erdos.Operator):
 
         # Log heading
         file_name = os.path.join(
-            self._flags.data_path,
+            self.self._data_path,
             'heading-{}.json'.format(msg.timestamp.coordinates[0]))
         with open(file_name, 'w') as outfile:
             json.dump(str(self._current_transform.rotation.yaw), outfile)
 
         # Log speed
         file_name = os.path.join(
-            self._flags.data_path,
+            self.self._data_path,
             'speed-{}.json'.format(msg.timestamp.coordinates[0]))
         with open(file_name, 'w') as outfile:
             json.dump(str(msg.data.forward_speed), outfile)
@@ -208,7 +210,7 @@ class ChauffeurLoggerOperator(erdos.Operator):
         tl_img = Image.fromarray(tl_mask)
         tl_img = tl_img.convert('RGB')
         file_name = os.path.join(
-            self._flags.data_path,
+            self.self._data_path,
             'traffic_lights-{}.png'.format(msg.timestamp.coordinates[0]))
         tl_img.save(file_name)
 

--- a/pylot/loggers/gnss_logger_operator.py
+++ b/pylot/loggers/gnss_logger_operator.py
@@ -21,6 +21,7 @@ class GNSSLoggerOperator(erdos.Operator):
         _logger (:obj:`logging.Logger`): Instance to be used to log messages.
         _flags (absl.flags): Object to be used to access absl flags.
         _msg_cnt (:obj:`int`): Number of messages received.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, gnss_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags):
@@ -29,6 +30,8 @@ class GNSSLoggerOperator(erdos.Operator):
                                                  self.config.log_file_name)
         self._flags = flags
         self._msg_cnt = 0
+        self._data_path = os.path.join(self._flags.data_path, 'gnss')
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(gnss_stream: erdos.ReadStream):
@@ -49,7 +52,7 @@ class GNSSLoggerOperator(erdos.Operator):
             return
         assert len(msg.timestamp.coordinates) == 1
         timestamp = msg.timestamp.coordinates[0]
-        file_name = os.path.join(self._flags.data_path,
+        file_name = os.path.join(self._data_path,
                                  'gnss-{}.json'.format(timestamp))
         measurements = {
             "latitude": str(msg.latitude),

--- a/pylot/loggers/imu_logger_operator.py
+++ b/pylot/loggers/imu_logger_operator.py
@@ -21,6 +21,7 @@ class IMULoggerOperator(erdos.Operator):
         _logger (:obj:`logging.Logger`): Instance to be used to log messages.
         _flags (absl.flags): Object to be used to access absl flags.
         _msg_cnt (:obj:`int`): Number of messages received.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, imu_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags):
@@ -29,6 +30,8 @@ class IMULoggerOperator(erdos.Operator):
                                                  self.config.log_file_name)
         self._flags = flags
         self._msg_cnt = 0
+        self._data_path = os.path.join(self._flags.data_path, 'imu')
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(imu_stream: erdos.ReadStream):
@@ -49,7 +52,7 @@ class IMULoggerOperator(erdos.Operator):
             return
         assert len(msg.timestamp.coordinates) == 1
         timestamp = msg.timestamp.coordinates[0]
-        file_name = os.path.join(self._flags.data_path,
+        file_name = os.path.join(self._data_path,
                                  'imu-{}.json'.format(timestamp))
         measurements = {
             "transform": str(msg.transform),

--- a/pylot/loggers/lidar_logger_operator.py
+++ b/pylot/loggers/lidar_logger_operator.py
@@ -1,4 +1,6 @@
 """This module implements an operator that logs lidar point clouds."""
+import os
+
 import erdos
 
 
@@ -19,6 +21,7 @@ class LidarLoggerOperator(erdos.Operator):
         _pc_msg_cnt (:obj:`int`): Number of messages received.
         _filename_prefix (:obj:`str`): Used to construct the names of the files
              it logs to.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, lidar_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags,
@@ -29,6 +32,8 @@ class LidarLoggerOperator(erdos.Operator):
         self._flags = flags
         self._pc_msg_cnt = 0
         self._filename_prefix = filename_prefix
+        self._data_path = os.path.join(self._flags.data_path, filename_prefix)
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(lidar_stream: erdos.ReadStream):
@@ -49,5 +54,5 @@ class LidarLoggerOperator(erdos.Operator):
             return
         assert len(msg.timestamp.coordinates) == 1
         # Write the lidar information.
-        msg.point_cloud.save(msg.timestamp.coordinates[0],
-                             self._flags.data_path, self._filename_prefix)
+        msg.point_cloud.save(msg.timestamp.coordinates[0], self._data_path,
+                             self._filename_prefix)

--- a/pylot/loggers/multiple_object_tracker_logger_operator.py
+++ b/pylot/loggers/multiple_object_tracker_logger_operator.py
@@ -18,6 +18,7 @@ class MultipleObjectTrackerLoggerOperator(erdos.Operator):
         _logger (:obj:`logging.Logger`): Instance to be used to log messages.
         _flags (absl.flags): Object to be used to access absl flags.
         _msg_cnt (:obj:`int`): Number of messages received.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, obstacles_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags):
@@ -27,6 +28,9 @@ class MultipleObjectTrackerLoggerOperator(erdos.Operator):
                                                  self.config.log_file_name)
         self._flags = flags
         self._msg_cnt = 0
+        self._data_path = os.path.join(self._flags.data_path,
+                                       'multiple_object_tracker')
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(obstacles_stream: erdos.ReadStream):
@@ -55,7 +59,7 @@ class MultipleObjectTrackerLoggerOperator(erdos.Operator):
                 lines.append(obstacle.as_mot16_str(timestamp))
 
         # Write the data, MOT16 style: https://motchallenge.net/instructions/
-        file_name = os.path.join(self._flags.data_path,
+        file_name = os.path.join(self._data_path,
                                  'mot-{}.txt'.format(timestamp))
         with open(file_name, 'w') as outfile:
             outfile.writelines(lines)

--- a/pylot/loggers/pose_logger_operator.py
+++ b/pylot/loggers/pose_logger_operator.py
@@ -21,6 +21,7 @@ class PoseLoggerOperator(erdos.Operator):
         _logger (:obj:`logging.Logger`): Instance to be used to log messages.
         _flags (absl.flags): Object to be used to access absl flags.
         _msg_cnt (:obj:`int`): Number of messages received.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, pose_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags):
@@ -29,6 +30,8 @@ class PoseLoggerOperator(erdos.Operator):
                                                  self.config.log_file_name)
         self._flags = flags
         self._msg_cnt = 0
+        self._data_path = os.path.join(self._flags.data_path, 'pose')
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(pose_stream: erdos.ReadStream):
@@ -49,7 +52,7 @@ class PoseLoggerOperator(erdos.Operator):
             return
         assert len(msg.timestamp.coordinates) == 1
         timestamp = msg.timestamp.coordinates[0]
-        file_name = os.path.join(self._flags.data_path,
+        file_name = os.path.join(self._data_path,
                                  'pose-{}.json'.format(timestamp))
         measurements = {
             "x": str(msg.data.transform.location.x),

--- a/pylot/loggers/trajectory_logger_operator.py
+++ b/pylot/loggers/trajectory_logger_operator.py
@@ -19,6 +19,7 @@ class TrajectoryLoggerOperator(erdos.Operator):
         _logger (:obj:`logging.Logger`): Instance to be used to log messages.
         _flags (absl.flags): Object to be used to access absl flags.
         _msg_cnt (:obj:`int`): Number of messages received.
+        _data_path (:obj:`str`): Directory to which to log files.
     """
     def __init__(self, obstacle_tracking_stream: erdos.ReadStream,
                  finished_indicator_stream: erdos.WriteStream, flags):
@@ -27,6 +28,8 @@ class TrajectoryLoggerOperator(erdos.Operator):
                                                  self.config.log_file_name)
         self._flags = flags
         self._msg_cnt = 0
+        self._data_path = os.path.join(self._flags.data_path, 'trajectories')
+        os.makedirs(self._data_path, exist_ok=True)
 
     @staticmethod
     def connect(obstacle_tracking_stream: erdos.ReadStream):
@@ -53,7 +56,7 @@ class TrajectoryLoggerOperator(erdos.Operator):
         assert len(msg.timestamp.coordinates) == 1
         timestamp = msg.timestamp.coordinates[0]
         # Write the trajectories.
-        file_name = os.path.join(self._flags.data_path,
+        file_name = os.path.join(self._data_path,
                                  'trajectories-{}.json'.format(timestamp))
         with open(file_name, 'w') as outfile:
             json.dump(trajectories, outfile)


### PR DESCRIPTION
Organizes logs into folders for easier navigation and debugging.

For example, after 2 runs the data directory might be organized as follows:
```
data
├── 2021-06-03T23:45:28
│   ├── center camera
│   │   ├── center camera-5896.png
│   │   └── center camera-6196.png
│   ├── center depth camera
│   │   ├── center depth camera-5896.pkl
│   │   └── center depth camera-6196.pkl
│   ├── center lidar
│   │   ├── center lidar-5896.ply
│   │   └── center lidar-6196.ply
│   ├── center segmented camera
│   │   ├── center segmented camera-5896.png
│   │   └── center segmented camera-6196.png
│   ├── gnss
│   │   ├── gnss-5896.json
│   │   └── gnss-6196.json
│   ├── imu
│   │   ├── imu-5896.json
│   │   └── imu-6196.json
│   └── right camera
│       ├── right camera-5896.png
│       └── right camera-6196.png
└── 2021-06-03T23:49:59
    ├── center camera
    │   ├── center camera-5857.png
    │   ├── center camera-5907.png
    │   └── center camera-6207.png
    ├── center depth camera
    │   ├── center depth camera-5857.pkl
    │   ├── center depth camera-5907.pkl
    │   └── center depth camera-6207.pkl
    ├── center lidar
    │   ├── center lidar-5857.ply
    │   ├── center lidar-5907.ply
    │   └── center lidar-6207.ply
    ├── center segmented camera
    │   ├── center segmented camera-5857.png
    │   ├── center segmented camera-5907.png
    │   └── center segmented camera-6207.png
    ├── gnss
    │   ├── gnss-5857.json
    │   ├── gnss-5907.json
    │   └── gnss-6207.json
    ├── imu
    │   ├── imu-5857.json
    │   ├── imu-5907.json
    │   └── imu-6207.json
    └── right camera
        ├── right camera-5857.png
        ├── right camera-5907.png
        └── right camera-6207.png
```