### PR TITLE
[Bug] Support custom CARLA traffic manager ports

### DIFF
--- a/pylot/simulation/carla_operator.py
+++ b/pylot/simulation/carla_operator.py
@@ -110,7 +110,9 @@ class CarlaOperator(erdos.Operator):
             # Spawn ego vehicle, people and vehicles.
             (self._ego_vehicle, self._vehicle_ids,
              self._people) = pylot.simulation.utils.spawn_actors(
-                 self._client, self._world, self._simulator_version,
+                 self._client, self._world,
+                 self._flags.carla_traffic_manager_port,
+                 self._simulator_version,
                  self._flags.simulator_spawn_point_index,
                  self._flags.control == 'simulator_auto_pilot',
                  self._flags.simulator_num_people,

--- a/pylot/simulation/utils.py
+++ b/pylot/simulation/utils.py
@@ -166,11 +166,13 @@ def reset_world(world):
             actor.destroy()
 
 
-def spawn_actors(client, world, simulator_version: str,
-                 ego_spawn_point_index: int, auto_pilot: bool, num_people: int,
-                 num_vehicles: int, logger):
-    vehicle_ids = spawn_vehicles(client, world, num_vehicles, logger)
-    ego_vehicle = spawn_ego_vehicle(world, ego_spawn_point_index, auto_pilot)
+def spawn_actors(client, world, traffic_manager_port: int,
+                 simulator_version: str, ego_spawn_point_index: int,
+                 auto_pilot: bool, num_people: int, num_vehicles: int, logger):
+    vehicle_ids = spawn_vehicles(client, world, traffic_manager_port,
+                                 num_vehicles, logger)
+    ego_vehicle = spawn_ego_vehicle(world, traffic_manager_port,
+                                    ego_spawn_point_index, auto_pilot)
     people = []
 
     if check_simulator_version(simulator_version,
@@ -189,6 +191,7 @@ def spawn_actors(client, world, simulator_version: str,
 
 
 def spawn_ego_vehicle(world,
+                      traffic_manager_port: int,
                       spawn_point_index: int,
                       auto_pilot: bool,
                       blueprint: str = 'vehicle.lincoln.mkz2017'):
@@ -207,7 +210,7 @@ def spawn_ego_vehicle(world,
 
         ego_vehicle = world.try_spawn_actor(v_blueprint, start_pose)
     if auto_pilot:
-        ego_vehicle.set_autopilot(True)
+        ego_vehicle.set_autopilot(True, traffic_manager_port)
     return ego_vehicle
 
 
@@ -271,7 +274,8 @@ def spawn_people(client, world, num_people: int, logger):
     return (ped_ids, ped_control_ids)
 
 
-def spawn_vehicles(client, world, num_vehicles: int, logger):
+def spawn_vehicles(client, world, traffic_manager_port: int, num_vehicles: int,
+                   logger):
     """ Spawns vehicles at random locations inside the world.
 
     Args:
@@ -309,7 +313,8 @@ def spawn_vehicles(client, world, num_vehicles: int, logger):
 
         batch.append(
             command.SpawnActor(blueprint, transform).then(
-                command.SetAutopilot(command.FutureActor, True)))
+                command.SetAutopilot(command.FutureActor, True,
+                                     traffic_manager_port)))
 
     # Apply the batch and retrieve the identifiers.
     vehicle_ids = []


### PR DESCRIPTION
Fixes a bug where using a custom port for the CARLA traffic manager would result in the following error:
```RuntimeError: trying to create rpc server for traffic manager; but the system failed to create because of bind error.```

This error occurs because `command.SetAutopilot` and `ego_vehicle.set_autopilot` expect a `traffic_manager_port` argument which defaults to 8000.

This fix passes the correct traffic manager port as specified in Pylot's flags to these functions.