### PR TITLE
convert location to transform in simulator

### DIFF
--- a/pylot/map/hd_map.py
+++ b/pylot/map/hd_map.py
@@ -15,7 +15,7 @@ from carla import LaneType
 import erdos
 
 from pylot.perception.detection.lane import Lane
-from pylot.utils import Location, Transform
+from pylot.utils import Location, Rotation, Transform
 
 
 class HDMap(object):
@@ -307,12 +307,12 @@ class HDMap(object):
 
         # Get the left and right markings of the lane and send it as a message.
         left_markings = [
-            self._lateral_shift(w.transform, -w.lane_width * 0.5)
-            for w in lane_waypoints
+            Transform(self._lateral_shift(w.transform, -w.lane_width * 0.5),
+                      Rotation()) for w in lane_waypoints
         ]
         right_markings = [
-            self._lateral_shift(w.transform, w.lane_width * 0.5)
-            for w in lane_waypoints
+            Transform(self._lateral_shift(w.transform, w.lane_width * 0.5),
+                      Rotation()) for w in lane_waypoints
         ]
         return Lane(lane_id, left_markings, right_markings)
 

--- a/pylot/perception/detection/lane.py
+++ b/pylot/perception/detection/lane.py
@@ -45,7 +45,7 @@ class Lane(object):
             if inverse_transform:
                 # marking = inverse_transform * marking
                 marking = inverse_transform.transform_points(
-                    np.array([marking.as_numpy_array()]))
+                    np.array([marking.location.as_numpy_array()]))
                 marking = Vector3D(marking[0, 0], marking[0, 1], marking[0, 2])
             else:
                 marking = marking.location
@@ -63,7 +63,7 @@ class Lane(object):
             if inverse_transform:
                 # marking = inverse_transform * marking
                 marking = inverse_transform.transform_points(
-                    np.array([marking.as_numpy_array()]))
+                    np.array([marking.location.as_numpy_array()]))
                 marking = Vector3D(marking[0, 0], marking[0, 1], marking[0, 2])
             else:
                 marking = marking.location


### PR DESCRIPTION
Is there a reason why we use Transform instead of just Location for lane markings? I'm noticing somewhat noticeable latency from having to generate all the Transform objects instead of leaving them as location objects