### PR TITLE
Switch spawning order between ego and NPC vehicles

### DIFF
--- a/pylot/simulation/utils.py
+++ b/pylot/simulation/utils.py
@@ -168,10 +168,10 @@ def reset_world(world):
 def spawn_actors(client, world, traffic_manager_port: int,
                  simulator_version: str, ego_spawn_point_index: int,
                  auto_pilot: bool, num_people: int, num_vehicles: int, logger):
-    vehicle_ids = spawn_vehicles(client, world, traffic_manager_port,
-                                 num_vehicles, logger)
     ego_vehicle = spawn_ego_vehicle(world, traffic_manager_port,
                                     ego_spawn_point_index, auto_pilot)
+    vehicle_ids = spawn_vehicles(client, world, traffic_manager_port,
+                                 num_vehicles, logger)
     people = []
 
     if check_simulator_version(simulator_version,


### PR DESCRIPTION
I have tested on multiple towns and found that if the number of NPC vehicles is large (e.g., 100), then it's very likely to get stuck on the spawning ego vehicle. One possible condition to trigger this is that those NPC vehicles have taken the spawn point of the ego vehicle.

Spawning the ego vehicle first could be a more robust implementation.